### PR TITLE
fix: trip date handling + date pickers, explore tab, trip editing

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -38,7 +38,8 @@
             "imageWidth": 76
           }
         }
-      ]
+      ],
+      "@react-native-community/datetimepicker"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -17,6 +17,7 @@
     "@expo/metro-runtime": "^55.0.6",
     "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "^3.0.1",
+    "@react-native-community/datetimepicker": "8.6.0",
     "@react-native-google-signin/google-signin": "^16.1.2",
     "@react-navigation/bottom-tabs": "^7.7.3",
     "@react-navigation/elements": "^2.8.1",

--- a/apps/mobile/src/app/(tabs)/explore.tsx
+++ b/apps/mobile/src/app/(tabs)/explore.tsx
@@ -1,15 +1,249 @@
-import { Text, View } from "react-native";
-import { Screen } from "@/components/shared/Screen";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import {
+  ChevronRight,
+  Compass,
+  MapPin,
+  Search,
+  Star,
+} from "lucide-react-native";
+import { useUnstableNativeVariable } from "nativewind";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { client } from "@/api/client";
+
+type Destination = {
+  id: string;
+  name: string;
+  country: string;
+  countryCode: string;
+  slug: string;
+};
+
+type Place = {
+  id: string;
+  name: string;
+  category: string;
+  description: string | null;
+  rating: number | null;
+  isCurated: boolean;
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ATTRACTION: "Attraction",
+  RESTAURANT: "Restaurant",
+  HOTEL: "Hotel",
+  SHOPPING: "Shopping",
+  NIGHTLIFE: "Nightlife",
+  TRANSPORT: "Transport",
+  OTHER: "Other",
+};
+
+function CategoryBadge({ category }: { category: string }) {
+  return (
+    <View className="rounded-full bg-primary/10 px-2 py-0.5">
+      <Text className="text-xs font-medium text-primary">
+        {CATEGORY_LABELS[category] ?? category}
+      </Text>
+    </View>
+  );
+}
+
+function PlaceCard({ place }: { place: Place }) {
+  const mutedFg = useUnstableNativeVariable("--muted-foreground");
+  const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
+
+  return (
+    <View className="mr-3 w-56 rounded-xl border border-border bg-card p-3">
+      <View className="flex-row items-center justify-between">
+        <CategoryBadge category={place.category} />
+        {place.rating && (
+          <View className="flex-row items-center gap-1">
+            <Star size={12} color="#F59E0B" fill="#F59E0B" />
+            <Text className="text-xs font-medium text-foreground">
+              {place.rating.toFixed(1)}
+            </Text>
+          </View>
+        )}
+      </View>
+      <Text className="mt-2 text-base font-semibold text-foreground" numberOfLines={1}>
+        {place.name}
+      </Text>
+      {place.description && (
+        <Text className="mt-1 text-sm text-muted-foreground" numberOfLines={2}>
+          {place.description}
+        </Text>
+      )}
+      {place.isCurated && (
+        <Text className="mt-1.5 text-xs font-medium text-chart-2">
+          Curated pick
+        </Text>
+      )}
+    </View>
+  );
+}
+
+function DestinationSection({ destination }: { destination: Destination }) {
+  const mutedFg = useUnstableNativeVariable("--muted-foreground");
+  const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
+  const router = useRouter();
+
+  const placesQuery = useQuery({
+    queryKey: ["places", destination.id],
+    queryFn: async () => {
+      const res = await client.api.v1
+        .destinations({ destId: destination.id })
+        .places.get({ query: {} });
+      if (res.error) throw new Error("Failed to load places");
+      return res.data;
+    },
+  });
+
+  const places = (placesQuery.data?.places ?? []) as Place[];
+  const topPlaces = places.slice(0, 6);
+
+  return (
+    <View className="gap-3">
+      <Pressable
+        onPress={() =>
+          router.push({
+            pathname: "/trip/new",
+            params: { destId: destination.id, destName: destination.name, destCountry: destination.country },
+          } as never)
+        }
+        className="flex-row items-center justify-between active:opacity-80"
+      >
+        <View className="flex-row items-center gap-2">
+          <View className="h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+            <MapPin size={18} color={mutedColor} />
+          </View>
+          <View>
+            <Text className="text-lg font-bold text-foreground">
+              {destination.name}
+            </Text>
+            <Text className="text-sm text-muted-foreground">
+              {destination.country}
+            </Text>
+          </View>
+        </View>
+        <View className="flex-row items-center gap-1">
+          <Text className="text-sm text-primary">Plan trip</Text>
+          <ChevronRight size={16} color={mutedColor} />
+        </View>
+      </Pressable>
+
+      {placesQuery.isLoading && (
+        <View className="items-center py-4">
+          <ActivityIndicator />
+        </View>
+      )}
+
+      {topPlaces.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerClassName="pl-0.5"
+        >
+          {topPlaces.map((place) => (
+            <PlaceCard key={place.id} place={place} />
+          ))}
+        </ScrollView>
+      )}
+
+      {!placesQuery.isLoading && topPlaces.length === 0 && (
+        <Text className="text-sm text-muted-foreground">
+          No places available yet
+        </Text>
+      )}
+    </View>
+  );
+}
 
 export default function ExploreScreen() {
+  const mutedFg = useUnstableNativeVariable("--muted-foreground");
+  const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const destQuery = useQuery({
+    queryKey: ["explore-destinations", searchQuery],
+    queryFn: async () => {
+      const res = await client.api.v1.destinations.get({
+        query: { q: searchQuery },
+      });
+      if (res.error) throw new Error("Failed to load destinations");
+      return res.data;
+    },
+  });
+
+  const destinations = (destQuery.data?.destinations ?? []) as Destination[];
+
   return (
-    <Screen>
-      <View className="rounded-2xl border border-border bg-card p-5">
-        <Text className="text-2xl font-bold text-card-foreground">Explore</Text>
-        <Text className="mt-2 text-base leading-6 text-muted-foreground">
-          Curated recommendations and local favorites will appear here.
-        </Text>
-      </View>
-    </Screen>
+    <SafeAreaView edges={["top", "left", "right"]} className="flex-1 bg-background">
+      <ScrollView
+        contentContainerClassName="flex-grow px-5 pt-6 pb-6"
+        refreshControl={
+          <RefreshControl
+            refreshing={destQuery.isRefetching}
+            onRefresh={() => destQuery.refetch()}
+          />
+        }
+      >
+        <View className="gap-6">
+          {/* Header */}
+          <View>
+            <Text className="text-2xl font-bold text-foreground">Explore</Text>
+            <Text className="mt-1 text-sm text-muted-foreground">
+              Discover destinations and plan your next adventure
+            </Text>
+          </View>
+
+          {/* Search */}
+          <View className="flex-row items-center rounded-xl border border-border bg-card px-3">
+            <Search size={18} color={mutedColor} />
+            <TextInput
+              className="ml-2 flex-1 py-3 text-base text-foreground"
+              placeholder="Search destinations..."
+              placeholderTextColor={mutedColor}
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+            />
+          </View>
+
+          {/* Loading */}
+          {destQuery.isLoading && (
+            <View className="items-center py-8">
+              <ActivityIndicator />
+            </View>
+          )}
+
+          {/* Empty */}
+          {!destQuery.isLoading && destinations.length === 0 && searchQuery.length > 0 && (
+            <View className="items-center rounded-2xl border border-border bg-card py-8">
+              <Compass size={32} color={mutedColor} />
+              <Text className="mt-2 text-base font-medium text-foreground">
+                No destinations found
+              </Text>
+              <Text className="mt-1 text-sm text-muted-foreground">
+                Try a different search term
+              </Text>
+            </View>
+          )}
+
+          {/* Destination list */}
+          {destinations.map((dest) => (
+            <DestinationSection key={dest.id} destination={dest} />
+          ))}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,46 +1,45 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import {
+  Calendar,
   MapPin,
   Plus,
   Settings,
 } from "lucide-react-native";
 import { useUnstableNativeVariable } from "nativewind";
-import { useEffect } from "react";
-import { ActivityIndicator, Pressable, Text, View } from "react-native";
+import { useCallback, useEffect } from "react";
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { client } from "@/api/client";
-import { Button } from "@/components/shared/Button";
 import { Screen } from "@/components/shared/Screen";
 import { useAuthStore } from "@/store/authStore";
 import { useTripStore, type Trip } from "@/store/tripStore";
+import { cn, daysUntil, formatDateRange } from "@/lib/utils";
 
-function formatDateRange(start: string, end: string) {
-  const s = new Date(start);
-  const e = new Date(end);
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  return `${s.toLocaleDateString("en-US", opts)} – ${e.toLocaleDateString("en-US", opts)}`;
-}
-
-function TripCard({ trip, onPress }: { trip: Trip; onPress: () => void }) {
-  const mutedFg = useUnstableNativeVariable("--muted-foreground");
-  const mutedColor = mutedFg ? `hsl(${mutedFg})` : undefined;
-
+function getTripStatus(trip: Trip) {
   const now = new Date();
   const start = new Date(trip.startDate);
   const end = new Date(trip.endDate);
   const isUpcoming = start > now;
   const isActive = start <= now && end >= now;
-  const badge = isActive ? "Active" : isUpcoming ? "Upcoming" : "Past";
-  const badgeClass = isActive
-    ? "bg-chart-2/20"
-    : isUpcoming
-      ? "bg-primary/20"
-      : "bg-muted";
-  const badgeTextClass = isActive
-    ? "text-chart-2"
-    : isUpcoming
-      ? "text-primary"
-      : "text-muted-foreground";
+
+  if (isActive) {
+    const dayNum = Math.ceil((now.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+    const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+    return { badge: "Active", badgeClass: "bg-chart-2/20", textClass: "text-chart-2", subtitle: `Day ${dayNum} of ${totalDays}` };
+  }
+  if (isUpcoming) {
+    const days = daysUntil(trip.startDate);
+    const subtitle = days === 0 ? "Starts today!" : days === 1 ? "Starts tomorrow" : `In ${days} days`;
+    return { badge: "Upcoming", badgeClass: "bg-primary/20", textClass: "text-primary", subtitle };
+  }
+  return { badge: "Past", badgeClass: "bg-muted", textClass: "text-muted-foreground", subtitle: "Completed" };
+}
+
+function TripCard({ trip, onPress }: { trip: Trip; onPress: () => void }) {
+  const mutedFg = useUnstableNativeVariable("--muted-foreground");
+  const mutedColor = mutedFg ? `hsl(${mutedFg})` : undefined;
+  const status = getTripStatus(trip);
 
   return (
     <Pressable
@@ -58,14 +57,20 @@ function TripCard({ trip, onPress }: { trip: Trip; onPress: () => void }) {
             </Text>
           </View>
           <Text className="text-lg font-bold text-foreground">{trip.title}</Text>
-          <Text className="text-sm text-muted-foreground">
-            {formatDateRange(trip.startDate, trip.endDate)}
-          </Text>
+          <View className="flex-row items-center gap-2">
+            <Calendar size={13} color={mutedColor} />
+            <Text className="text-sm text-muted-foreground">
+              {formatDateRange(trip.startDate, trip.endDate)}
+            </Text>
+          </View>
         </View>
-        <View className={`rounded-full px-2.5 py-1 ${badgeClass}`}>
-          <Text className={`text-xs font-semibold ${badgeTextClass}`}>
-            {badge}
-          </Text>
+        <View className="items-end gap-1">
+          <View className={cn("rounded-full px-2.5 py-1", status.badgeClass)}>
+            <Text className={cn("text-xs font-semibold", status.textClass)}>
+              {status.badge}
+            </Text>
+          </View>
+          <Text className="text-xs text-muted-foreground">{status.subtitle}</Text>
         </View>
       </View>
     </Pressable>
@@ -79,6 +84,8 @@ export default function HomeScreen() {
   const setActiveTripId = useTripStore((s) => s.setActiveTripId);
   const foreground = useUnstableNativeVariable("--foreground");
   const iconColor = foreground ? `hsl(${foreground})` : undefined;
+  const mutedFg = useUnstableNativeVariable("--muted-foreground");
+  const mutedColor = mutedFg ? `hsl(${mutedFg})` : undefined;
   const displayName = user?.name?.split(" ")[0] ?? "there";
 
   const tripsQuery = useQuery({
@@ -98,75 +105,145 @@ export default function HomeScreen() {
 
   const trips = (tripsQuery.data?.trips ?? []) as Trip[];
 
+  const activeTrips = trips.filter((t) => {
+    const now = new Date();
+    return new Date(t.startDate) <= now && new Date(t.endDate) >= now;
+  });
+  const upcomingTrips = trips.filter((t) => new Date(t.startDate) > new Date());
+  const pastTrips = trips.filter((t) => new Date(t.endDate) < new Date());
+
+  const onRefresh = useCallback(() => {
+    tripsQuery.refetch();
+  }, [tripsQuery]);
+
   return (
-    <Screen scrollable contentClassName="pb-6">
-      <View className="gap-6">
-        {/* Header */}
-        <View className="flex-row items-start justify-between">
-          <View>
-            <Text className="text-2xl font-bold text-foreground">
-              Hello, {displayName}!
-            </Text>
-            <Text className="mt-1 text-sm text-muted-foreground">
-              {trips.length} {trips.length === 1 ? "trip" : "trips"} planned
-            </Text>
-          </View>
-          <Pressable
-            onPress={() => router.push("/settings" as never)}
-            className="h-10 w-10 items-center justify-center rounded-full border border-border bg-card active:opacity-80"
-            accessibilityRole="button"
-            accessibilityLabel="Settings"
-          >
-            <Settings size={20} color={iconColor} />
-          </Pressable>
-        </View>
-
-        {/* Create trip button */}
-        <Pressable
-          onPress={() => router.push("/trip/new" as never)}
-          className="flex-row items-center justify-center gap-2 rounded-2xl border border-dashed border-primary/40 bg-primary/10 py-4 active:opacity-90"
-          accessibilityRole="button"
-          accessibilityLabel="Create a new trip"
-        >
-          <Plus size={20} color={iconColor} />
-          <Text className="text-base font-semibold text-primary">
-            Plan a New Trip
-          </Text>
-        </Pressable>
-
-        {/* Trip list */}
-        {tripsQuery.isLoading && (
-          <View className="items-center py-8">
-            <ActivityIndicator />
-            <Text className="mt-2 text-sm text-muted-foreground">
-              Loading your trips...
-            </Text>
-          </View>
-        )}
-
-        {!tripsQuery.isLoading && trips.length === 0 && (
-          <View className="items-center rounded-2xl border border-border bg-card py-10">
-            <MapPin size={40} color={iconColor} />
-            <Text className="mt-3 text-lg font-semibold text-foreground">
-              No trips yet
-            </Text>
-            <Text className="mt-1 text-sm text-muted-foreground">
-              Tap above to plan your first adventure
-            </Text>
-          </View>
-        )}
-
-        {trips.map((trip) => (
-          <TripCard
-            key={trip.id}
-            trip={trip}
-            onPress={() => {
-              setActiveTripId(trip.id);
-              router.push(`/trip/${trip.id}` as never);
-            }}
+    <SafeAreaView edges={["top", "left", "right"]} className="flex-1 bg-background">
+      <ScrollView
+        contentContainerClassName="flex-grow px-5 pt-6 pb-6"
+        refreshControl={
+          <RefreshControl
+            refreshing={tripsQuery.isRefetching}
+            onRefresh={onRefresh}
           />
-        ))}
-      </View>
-    </Screen>
+        }
+      >
+        <View className="gap-6">
+          {/* Header */}
+          <View className="flex-row items-start justify-between">
+            <View>
+              <Text className="text-2xl font-bold text-foreground">
+                Hello, {displayName}!
+              </Text>
+              <Text className="mt-1 text-sm text-muted-foreground">
+                {trips.length === 0
+                  ? "Ready to plan your first trip?"
+                  : `${trips.length} ${trips.length === 1 ? "trip" : "trips"} planned`}
+              </Text>
+            </View>
+            <Pressable
+              onPress={() => router.push("/settings" as never)}
+              className="h-10 w-10 items-center justify-center rounded-full border border-border bg-card active:opacity-80"
+              accessibilityRole="button"
+              accessibilityLabel="Settings"
+            >
+              <Settings size={20} color={iconColor} />
+            </Pressable>
+          </View>
+
+          {/* Create trip button */}
+          <Pressable
+            onPress={() => router.push("/trip/new" as never)}
+            className="flex-row items-center justify-center gap-2 rounded-2xl border border-dashed border-primary/40 bg-primary/10 py-4 active:opacity-90"
+            accessibilityRole="button"
+            accessibilityLabel="Create a new trip"
+          >
+            <Plus size={20} color={iconColor} />
+            <Text className="text-base font-semibold text-primary">
+              Plan a New Trip
+            </Text>
+          </Pressable>
+
+          {/* Loading */}
+          {tripsQuery.isLoading && (
+            <View className="items-center py-8">
+              <ActivityIndicator />
+              <Text className="mt-2 text-sm text-muted-foreground">
+                Loading your trips...
+              </Text>
+            </View>
+          )}
+
+          {/* Empty */}
+          {!tripsQuery.isLoading && trips.length === 0 && (
+            <View className="items-center rounded-2xl border border-border bg-card py-10">
+              <MapPin size={40} color={mutedColor} />
+              <Text className="mt-3 text-lg font-semibold text-foreground">
+                No trips yet
+              </Text>
+              <Text className="mt-1 text-sm text-muted-foreground">
+                Tap above to plan your first adventure
+              </Text>
+            </View>
+          )}
+
+          {/* Active trips */}
+          {activeTrips.length > 0 && (
+            <View className="gap-3">
+              <Text className="text-sm font-semibold text-chart-2">
+                ACTIVE NOW
+              </Text>
+              {activeTrips.map((trip) => (
+                <TripCard
+                  key={trip.id}
+                  trip={trip}
+                  onPress={() => {
+                    setActiveTripId(trip.id);
+                    router.push(`/trip/${trip.id}` as never);
+                  }}
+                />
+              ))}
+            </View>
+          )}
+
+          {/* Upcoming trips */}
+          {upcomingTrips.length > 0 && (
+            <View className="gap-3">
+              <Text className="text-sm font-semibold text-primary">
+                UPCOMING
+              </Text>
+              {upcomingTrips.map((trip) => (
+                <TripCard
+                  key={trip.id}
+                  trip={trip}
+                  onPress={() => {
+                    setActiveTripId(trip.id);
+                    router.push(`/trip/${trip.id}` as never);
+                  }}
+                />
+              ))}
+            </View>
+          )}
+
+          {/* Past trips */}
+          {pastTrips.length > 0 && (
+            <View className="gap-3">
+              <Text className="text-sm font-semibold text-muted-foreground">
+                PAST TRIPS
+              </Text>
+              {pastTrips.map((trip) => (
+                <TripCard
+                  key={trip.id}
+                  trip={trip}
+                  onPress={() => {
+                    setActiveTripId(trip.id);
+                    router.push(`/trip/${trip.id}` as never);
+                  }}
+                />
+              ))}
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }

--- a/apps/mobile/src/app/(tabs)/itinerary.tsx
+++ b/apps/mobile/src/app/(tabs)/itinerary.tsx
@@ -12,11 +12,12 @@ import { client } from "@/api/client";
 import { Button } from "@/components/shared/Button";
 import { Screen } from "@/components/shared/Screen";
 import { useTripStore } from "@/store/tripStore";
+import { formatDate, toDateOnly } from "@/lib/utils";
 
 type ItineraryItem = {
   id: string;
   title: string;
-  date: string;
+  date: string | Date;
   startTime: string | null;
   endTime: string | null;
   notes: string | null;
@@ -24,18 +25,10 @@ type ItineraryItem = {
   order: number;
 };
 
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
-}
-
 function groupByDate(items: ItineraryItem[]) {
   const groups: Record<string, ItineraryItem[]> = {};
   for (const item of items) {
-    const key = item.date.split("T")[0];
+    const key = toDateOnly(item.date);
     if (!groups[key]) groups[key] = [];
     groups[key].push(item);
   }
@@ -48,8 +41,6 @@ export default function ItineraryTabScreen() {
   const trips = useTripStore((s) => s.trips);
   const mutedFg = useUnstableNativeVariable("--muted-foreground");
   const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
-  const foreground = useUnstableNativeVariable("--foreground");
-  const iconColor = foreground ? `hsl(${foreground})` : undefined;
 
   const itemsQuery = useQuery({
     queryKey: ["itinerary", activeTrip?.id],
@@ -98,6 +89,7 @@ export default function ItineraryTabScreen() {
   const items = (itemsQuery.data?.items ?? []) as ItineraryItem[];
   const grouped = groupByDate(items);
   const doneCount = items.filter((i) => i.isDone).length;
+  const progress = items.length > 0 ? doneCount / items.length : 0;
 
   return (
     <Screen scrollable contentClassName="pb-6">
@@ -113,12 +105,25 @@ export default function ItineraryTabScreen() {
           <Text className="text-2xl font-bold text-foreground">
             {activeTrip.title}
           </Text>
-          {items.length > 0 && (
-            <Text className="mt-1 text-sm text-muted-foreground">
-              {doneCount}/{items.length} completed
-            </Text>
-          )}
         </View>
+
+        {/* Progress bar */}
+        {items.length > 0 && (
+          <View className="gap-2">
+            <View className="flex-row items-center justify-between">
+              <Text className="text-sm font-medium text-foreground">Progress</Text>
+              <Text className="text-sm text-muted-foreground">
+                {doneCount}/{items.length} completed
+              </Text>
+            </View>
+            <View className="h-2.5 overflow-hidden rounded-full bg-muted">
+              <View
+                className="h-full rounded-full bg-chart-2"
+                style={{ width: `${progress * 100}%` }}
+              />
+            </View>
+          </View>
+        )}
 
         <Button
           label="Open Full Itinerary"
@@ -151,9 +156,10 @@ export default function ItineraryTabScreen() {
               {dayItems.length === 1 ? "item" : "items"}
             </Text>
             {dayItems.map((item) => (
-              <View
+              <Pressable
                 key={item.id}
-                className="flex-row items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
+                onPress={() => router.push(`/trip/${activeTrip.id}` as never)}
+                className="flex-row items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 active:opacity-90"
               >
                 {item.isDone ? (
                   <CheckCircle2 size={20} color="#22C55E" />
@@ -173,7 +179,7 @@ export default function ItineraryTabScreen() {
                     </Text>
                   )}
                 </View>
-              </View>
+              </Pressable>
             ))}
           </View>
         ))}

--- a/apps/mobile/src/app/trip/[id].tsx
+++ b/apps/mobile/src/app/trip/[id].tsx
@@ -1,3 +1,4 @@
+import DateTimePicker from "@react-native-community/datetimepicker";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
@@ -5,17 +6,20 @@ import {
   CheckCircle2,
   ChevronLeft,
   Circle,
+  Clock,
+  Edit3,
   MapPin,
   Plus,
   Trash2,
 } from "lucide-react-native";
 import { useUnstableNativeVariable } from "nativewind";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
   ActivityIndicator,
   Alert,
   Modal,
+  Platform,
   Pressable,
   Text,
   TextInput,
@@ -24,13 +28,14 @@ import {
 import { client } from "@/api/client";
 import { Button } from "@/components/shared/Button";
 import { Screen } from "@/components/shared/Screen";
+import { formatDate, toDateOnly } from "@/lib/utils";
 
 type ItineraryItem = {
   id: string;
   tripId: string;
   title: string;
   notes: string | null;
-  date: string;
+  date: string | Date;
   startTime: string | null;
   endTime: string | null;
   order: number;
@@ -38,18 +43,10 @@ type ItineraryItem = {
   placeId: string | null;
 };
 
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
-}
-
 function groupByDate(items: ItineraryItem[]) {
   const groups: Record<string, ItineraryItem[]> = {};
   for (const item of items) {
-    const key = item.date.split("T")[0];
+    const key = toDateOnly(item.date);
     if (!groups[key]) groups[key] = [];
     groups[key].push(item);
   }
@@ -66,12 +63,13 @@ export default function TripDetailScreen() {
   const iconColor = foreground ? `hsl(${foreground})` : undefined;
 
   const [showAddModal, setShowAddModal] = useState(false);
-  const [addDate, setAddDate] = useState("");
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [addDate, setAddDate] = useState<Date>(new Date());
 
   const tripQuery = useQuery({
     queryKey: ["trip", id],
     queryFn: async () => {
-      const res = await client.api.v1.trips({ id: id! }).get();
+      const res = await client.api.v1.trips({ tripId: id! }).get();
       if (res.error) throw new Error("Failed to load trip");
       return res.data;
     },
@@ -112,7 +110,7 @@ export default function TripDetailScreen() {
 
   const deleteTrip = useMutation({
     mutationFn: async () => {
-      const res = await client.api.v1.trips({ id: id! }).delete();
+      const res = await client.api.v1.trips({ tripId: id! }).delete();
       if (res.error) throw new Error("Failed to delete trip");
       return res.data;
     },
@@ -125,6 +123,8 @@ export default function TripDetailScreen() {
   const trip = tripQuery.data?.trip;
   const items = (itemsQuery.data?.items ?? []) as ItineraryItem[];
   const grouped = groupByDate(items);
+  const doneCount = items.filter((i) => i.isDone).length;
+  const progress = items.length > 0 ? doneCount / items.length : 0;
 
   if (tripQuery.isLoading) {
     return (
@@ -174,9 +174,17 @@ export default function TripDetailScreen() {
                 {trip.destination.name} · {trip.destination.countryCode}
               </Text>
             </View>
-            <Text className="text-2xl font-bold text-foreground">
-              {trip.title}
-            </Text>
+            <View className="flex-row items-center justify-between">
+              <Text className="flex-1 text-2xl font-bold text-foreground">
+                {trip.title}
+              </Text>
+              <Pressable
+                onPress={() => setShowEditModal(true)}
+                className="ml-2 rounded-lg border border-border bg-card p-2 active:opacity-80"
+              >
+                <Edit3 size={16} color={mutedColor} />
+              </Pressable>
+            </View>
             <View className="flex-row items-center gap-2">
               <Calendar size={14} color={mutedColor} />
               <Text className="text-sm text-muted-foreground">
@@ -186,12 +194,32 @@ export default function TripDetailScreen() {
           </View>
         )}
 
-        {/* Itinerary */}
+        {/* Progress bar */}
+        {items.length > 0 && (
+          <View className="gap-2">
+            <View className="flex-row items-center justify-between">
+              <Text className="text-sm font-medium text-foreground">
+                Progress
+              </Text>
+              <Text className="text-sm text-muted-foreground">
+                {doneCount}/{items.length} completed
+              </Text>
+            </View>
+            <View className="h-2.5 overflow-hidden rounded-full bg-muted">
+              <View
+                className="h-full rounded-full bg-chart-2"
+                style={{ width: `${progress * 100}%` }}
+              />
+            </View>
+          </View>
+        )}
+
+        {/* Itinerary header */}
         <View className="flex-row items-center justify-between">
           <Text className="text-lg font-bold text-foreground">Itinerary</Text>
           <Pressable
             onPress={() => {
-              setAddDate(trip?.startDate.split("T")[0] ?? "");
+              setAddDate(trip ? new Date(trip.startDate) : new Date());
               setShowAddModal(true);
             }}
             className="flex-row items-center gap-1 rounded-lg bg-primary px-3 py-2 active:opacity-90"
@@ -219,79 +247,117 @@ export default function TripDetailScreen() {
           </View>
         )}
 
-        {grouped.map(([date, dayItems]) => (
-          <View key={date} className="gap-2">
-            <Text className="text-sm font-semibold text-muted-foreground">
-              {formatDate(date)} · {dayItems.length}{" "}
-              {dayItems.length === 1 ? "item" : "items"}
-            </Text>
-            {dayItems.map((item) => (
-              <View
-                key={item.id}
-                className="flex-row items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
-              >
-                <Pressable
-                  onPress={() =>
-                    toggleDone.mutate({
-                      itemId: item.id,
-                      isDone: !item.isDone,
-                    })
-                  }
-                  accessibilityRole="checkbox"
-                  accessibilityState={{ checked: item.isDone }}
-                >
-                  {item.isDone ? (
-                    <CheckCircle2 size={22} color="#22C55E" />
-                  ) : (
-                    <Circle size={22} color={mutedColor} />
-                  )}
-                </Pressable>
-                <View className="flex-1">
-                  <Text
-                    className={`text-base font-medium ${item.isDone ? "text-muted-foreground line-through" : "text-foreground"}`}
-                  >
-                    {item.title}
+        {grouped.map(([date, dayItems]) => {
+          const dayDone = dayItems.filter((i) => i.isDone).length;
+          return (
+            <View key={date} className="gap-2">
+              <View className="flex-row items-center justify-between">
+                <Text className="text-sm font-semibold text-muted-foreground">
+                  {formatDate(date)} · {dayItems.length}{" "}
+                  {dayItems.length === 1 ? "item" : "items"}
+                </Text>
+                {dayItems.length > 0 && (
+                  <Text className="text-xs text-muted-foreground">
+                    {dayDone}/{dayItems.length} done
                   </Text>
-                  {(item.startTime || item.notes) && (
-                    <Text className="text-sm text-muted-foreground">
-                      {item.startTime && `${item.startTime}`}
-                      {item.startTime && item.endTime && ` – ${item.endTime}`}
-                      {item.notes && ` · ${item.notes}`}
-                    </Text>
-                  )}
-                </View>
-                <Pressable
-                  onPress={() =>
-                    Alert.alert("Delete Item", `Remove "${item.title}"?`, [
-                      { text: "Cancel", style: "cancel" },
-                      {
-                        text: "Delete",
-                        style: "destructive",
-                        onPress: () => deleteItem.mutate(item.id),
-                      },
-                    ])
-                  }
-                  className="active:opacity-80"
-                >
-                  <Trash2 size={18} color="#EF4444" />
-                </Pressable>
+                )}
               </View>
-            ))}
-          </View>
-        ))}
+              {dayItems.map((item) => (
+                <View
+                  key={item.id}
+                  className="flex-row items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
+                >
+                  <Pressable
+                    onPress={() =>
+                      toggleDone.mutate({
+                        itemId: item.id,
+                        isDone: !item.isDone,
+                      })
+                    }
+                    accessibilityRole="checkbox"
+                    accessibilityState={{ checked: item.isDone }}
+                  >
+                    {item.isDone ? (
+                      <CheckCircle2 size={22} color="#22C55E" />
+                    ) : (
+                      <Circle size={22} color={mutedColor} />
+                    )}
+                  </Pressable>
+                  <View className="flex-1">
+                    <Text
+                      className={`text-base font-medium ${item.isDone ? "text-muted-foreground line-through" : "text-foreground"}`}
+                    >
+                      {item.title}
+                    </Text>
+                    {(item.startTime || item.notes) && (
+                      <View className="mt-0.5 flex-row items-center gap-1">
+                        {item.startTime && (
+                          <>
+                            <Clock size={12} color={mutedColor} />
+                            <Text className="text-sm text-muted-foreground">
+                              {item.startTime}
+                              {item.endTime && ` – ${item.endTime}`}
+                            </Text>
+                          </>
+                        )}
+                        {item.notes && (
+                          <Text className="text-sm text-muted-foreground" numberOfLines={1}>
+                            {item.startTime ? " · " : ""}{item.notes}
+                          </Text>
+                        )}
+                      </View>
+                    )}
+                  </View>
+                  <Pressable
+                    onPress={() =>
+                      Alert.alert("Delete Item", `Remove "${item.title}"?`, [
+                        { text: "Cancel", style: "cancel" },
+                        {
+                          text: "Delete",
+                          style: "destructive",
+                          onPress: () => deleteItem.mutate(item.id),
+                        },
+                      ])
+                    }
+                    className="active:opacity-80"
+                  >
+                    <Trash2 size={18} color="#EF4444" />
+                  </Pressable>
+                </View>
+              ))}
+            </View>
+          );
+        })}
       </View>
 
-      {/* Add item modal */}
       <AddItemModal
         visible={showAddModal}
         tripId={id!}
         defaultDate={addDate}
+        tripStartDate={trip ? new Date(trip.startDate) : undefined}
+        tripEndDate={trip ? new Date(trip.endDate) : undefined}
         onClose={() => setShowAddModal(false)}
         onSuccess={() => {
           setShowAddModal(false);
           queryClient.invalidateQueries({ queryKey: ["itinerary", id] });
         }}
       />
+
+      {trip && (
+        <EditTripModal
+          visible={showEditModal}
+          tripId={id!}
+          currentTitle={trip.title}
+          currentStartDate={new Date(trip.startDate)}
+          currentEndDate={new Date(trip.endDate)}
+          onClose={() => setShowEditModal(false)}
+          onSuccess={() => {
+            setShowEditModal(false);
+            queryClient.invalidateQueries({ queryKey: ["trip", id] });
+            queryClient.invalidateQueries({ queryKey: ["trips"] });
+          }}
+        />
+      )}
     </Screen>
   );
 }
@@ -300,43 +366,49 @@ function AddItemModal({
   visible,
   tripId,
   defaultDate,
+  tripStartDate,
+  tripEndDate,
   onClose,
   onSuccess,
 }: {
   visible: boolean;
   tripId: string;
-  defaultDate: string;
+  defaultDate: Date;
+  tripStartDate?: Date;
+  tripEndDate?: Date;
   onClose: () => void;
   onSuccess: () => void;
 }) {
   const mutedFg = useUnstableNativeVariable("--muted-foreground");
   const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
 
+  const [selectedDate, setSelectedDate] = useState(defaultDate);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [showStartTimePicker, setShowStartTimePicker] = useState(false);
+  const [showEndTimePicker, setShowEndTimePicker] = useState(false);
+  const [startTimeDate, setStartTimeDate] = useState<Date | null>(null);
+  const [endTimeDate, setEndTimeDate] = useState<Date | null>(null);
+
   const { control, handleSubmit, reset } = useForm({
     defaultValues: {
       title: "",
-      date: defaultDate,
-      startTime: "",
-      endTime: "",
       notes: "",
     },
   });
 
+  const formatTime = (d: Date) =>
+    d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+
   const addMutation = useMutation({
-    mutationFn: async (values: {
-      title: string;
-      date: string;
-      startTime: string;
-      endTime: string;
-      notes: string;
-    }) => {
+    mutationFn: async (values: { title: string; notes: string }) => {
+      const dateStr = toDateOnly(selectedDate);
       const res = await client.api.v1
         .trips({ tripId })
         ["itinerary-items"].post({
           title: values.title,
-          date: new Date(values.date).toISOString(),
-          ...(values.startTime && { startTime: values.startTime }),
-          ...(values.endTime && { endTime: values.endTime }),
+          date: new Date(dateStr).toISOString(),
+          ...(startTimeDate && { startTime: formatTime(startTimeDate) }),
+          ...(endTimeDate && { endTime: formatTime(endTimeDate) }),
           ...(values.notes && { notes: values.notes }),
         });
       if (res.error) throw new Error("Failed to add item");
@@ -344,9 +416,20 @@ function AddItemModal({
     },
     onSuccess: () => {
       reset();
+      setStartTimeDate(null);
+      setEndTimeDate(null);
+      setSelectedDate(defaultDate);
       onSuccess();
     },
   });
+
+  const handleClose = () => {
+    reset();
+    setStartTimeDate(null);
+    setEndTimeDate(null);
+    setSelectedDate(defaultDate);
+    onClose();
+  };
 
   return (
     <Modal visible={visible} animationType="slide" transparent>
@@ -354,7 +437,7 @@ function AddItemModal({
         <View className="rounded-t-3xl bg-background px-5 pb-10 pt-6">
           <View className="mb-5 flex-row items-center justify-between">
             <Text className="text-lg font-bold text-foreground">Add Item</Text>
-            <Pressable onPress={onClose}>
+            <Pressable onPress={handleClose}>
               <Text className="text-base font-medium text-primary">Cancel</Text>
             </Pressable>
           </View>
@@ -375,47 +458,83 @@ function AddItemModal({
               )}
             />
 
-            <Controller
-              control={control}
-              name="date"
-              render={({ field: { onChange, value } }) => (
-                <TextInput
-                  className="rounded-xl border border-border bg-card px-4 py-3 text-base text-foreground"
-                  placeholder="Date (YYYY-MM-DD)"
-                  placeholderTextColor={mutedColor}
-                  value={value}
-                  onChangeText={onChange}
+            {/* Date picker */}
+            <View className="gap-1">
+              <Text className="text-sm font-medium text-muted-foreground">Date</Text>
+              <Pressable
+                onPress={() => setShowDatePicker(true)}
+                className="flex-row items-center gap-2 rounded-xl border border-border bg-card px-4 py-3"
+              >
+                <Calendar size={16} color={mutedColor} />
+                <Text className="text-base text-foreground">
+                  {formatDate(selectedDate)}
+                </Text>
+              </Pressable>
+              {showDatePicker && (
+                <DateTimePicker
+                  value={selectedDate}
+                  mode="date"
+                  display={Platform.OS === "ios" ? "spinner" : "default"}
+                  minimumDate={tripStartDate}
+                  maximumDate={tripEndDate}
+                  onChange={(_, date) => {
+                    setShowDatePicker(Platform.OS === "ios");
+                    if (date) setSelectedDate(date);
+                  }}
                 />
               )}
-            />
+            </View>
 
+            {/* Time pickers */}
             <View className="flex-row gap-3">
-              <Controller
-                control={control}
-                name="startTime"
-                render={({ field: { onChange, value } }) => (
-                  <TextInput
-                    className="flex-1 rounded-xl border border-border bg-card px-4 py-3 text-base text-foreground"
-                    placeholder="Start (HH:MM)"
-                    placeholderTextColor={mutedColor}
-                    value={value}
-                    onChangeText={onChange}
+              <View className="flex-1 gap-1">
+                <Text className="text-sm font-medium text-muted-foreground">Start Time</Text>
+                <Pressable
+                  onPress={() => setShowStartTimePicker(true)}
+                  className="flex-row items-center gap-2 rounded-xl border border-border bg-card px-4 py-3"
+                >
+                  <Clock size={16} color={mutedColor} />
+                  <Text className={`text-base ${startTimeDate ? "text-foreground" : "text-muted-foreground"}`}>
+                    {startTimeDate ? formatTime(startTimeDate) : "Optional"}
+                  </Text>
+                </Pressable>
+                {showStartTimePicker && (
+                  <DateTimePicker
+                    value={startTimeDate ?? new Date()}
+                    mode="time"
+                    is24Hour
+                    display={Platform.OS === "ios" ? "spinner" : "default"}
+                    onChange={(_, date) => {
+                      setShowStartTimePicker(Platform.OS === "ios");
+                      if (date) setStartTimeDate(date);
+                    }}
                   />
                 )}
-              />
-              <Controller
-                control={control}
-                name="endTime"
-                render={({ field: { onChange, value } }) => (
-                  <TextInput
-                    className="flex-1 rounded-xl border border-border bg-card px-4 py-3 text-base text-foreground"
-                    placeholder="End (HH:MM)"
-                    placeholderTextColor={mutedColor}
-                    value={value}
-                    onChangeText={onChange}
+              </View>
+              <View className="flex-1 gap-1">
+                <Text className="text-sm font-medium text-muted-foreground">End Time</Text>
+                <Pressable
+                  onPress={() => setShowEndTimePicker(true)}
+                  className="flex-row items-center gap-2 rounded-xl border border-border bg-card px-4 py-3"
+                >
+                  <Clock size={16} color={mutedColor} />
+                  <Text className={`text-base ${endTimeDate ? "text-foreground" : "text-muted-foreground"}`}>
+                    {endTimeDate ? formatTime(endTimeDate) : "Optional"}
+                  </Text>
+                </Pressable>
+                {showEndTimePicker && (
+                  <DateTimePicker
+                    value={endTimeDate ?? new Date()}
+                    mode="time"
+                    is24Hour
+                    display={Platform.OS === "ios" ? "spinner" : "default"}
+                    onChange={(_, date) => {
+                      setShowEndTimePicker(Platform.OS === "ios");
+                      if (date) setEndTimeDate(date);
+                    }}
                   />
                 )}
-              />
+              </View>
             </View>
 
             <Controller
@@ -439,6 +558,142 @@ function AddItemModal({
               label="Add to Itinerary"
               onPress={() => void handleSubmit((v) => addMutation.mutate(v))()}
               loading={addMutation.isPending}
+            />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function EditTripModal({
+  visible,
+  tripId,
+  currentTitle,
+  currentStartDate,
+  currentEndDate,
+  onClose,
+  onSuccess,
+}: {
+  visible: boolean;
+  tripId: string;
+  currentTitle: string;
+  currentStartDate: Date;
+  currentEndDate: Date;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const mutedFg = useUnstableNativeVariable("--muted-foreground");
+  const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
+
+  const [title, setTitle] = useState(currentTitle);
+  const [startDate, setStartDate] = useState(currentStartDate);
+  const [endDate, setEndDate] = useState(currentEndDate);
+  const [showStartPicker, setShowStartPicker] = useState(false);
+  const [showEndPicker, setShowEndPicker] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setTitle(currentTitle);
+      setStartDate(currentStartDate);
+      setEndDate(currentEndDate);
+    }
+  }, [visible, currentTitle, currentStartDate, currentEndDate]);
+
+  const editMutation = useMutation({
+    mutationFn: async () => {
+      const res = await client.api.v1.trips({ tripId }).patch({
+        title,
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+      });
+      if (res.error) throw new Error("Failed to update trip");
+      return res.data;
+    },
+    onSuccess,
+  });
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent>
+      <View className="flex-1 justify-end bg-black/50">
+        <View className="rounded-t-3xl bg-background px-5 pb-10 pt-6">
+          <View className="mb-5 flex-row items-center justify-between">
+            <Text className="text-lg font-bold text-foreground">Edit Trip</Text>
+            <Pressable onPress={onClose}>
+              <Text className="text-base font-medium text-primary">Cancel</Text>
+            </Pressable>
+          </View>
+
+          <View className="gap-4">
+            <View className="gap-1">
+              <Text className="text-sm font-medium text-muted-foreground">Title</Text>
+              <TextInput
+                className="rounded-xl border border-border bg-card px-4 py-3 text-base text-foreground"
+                value={title}
+                onChangeText={setTitle}
+                maxLength={100}
+                placeholderTextColor={mutedColor}
+              />
+            </View>
+
+            <View className="flex-row gap-3">
+              <View className="flex-1 gap-1">
+                <Text className="text-sm font-medium text-muted-foreground">Start Date</Text>
+                <Pressable
+                  onPress={() => setShowStartPicker(true)}
+                  className="flex-row items-center gap-2 rounded-xl border border-border bg-card px-4 py-3"
+                >
+                  <Calendar size={16} color={mutedColor} />
+                  <Text className="text-base text-foreground">
+                    {formatDate(startDate)}
+                  </Text>
+                </Pressable>
+                {showStartPicker && (
+                  <DateTimePicker
+                    value={startDate}
+                    mode="date"
+                    display={Platform.OS === "ios" ? "spinner" : "default"}
+                    onChange={(_, date) => {
+                      setShowStartPicker(Platform.OS === "ios");
+                      if (date) {
+                        setStartDate(date);
+                        if (date > endDate) setEndDate(date);
+                      }
+                    }}
+                  />
+                )}
+              </View>
+              <View className="flex-1 gap-1">
+                <Text className="text-sm font-medium text-muted-foreground">End Date</Text>
+                <Pressable
+                  onPress={() => setShowEndPicker(true)}
+                  className="flex-row items-center gap-2 rounded-xl border border-border bg-card px-4 py-3"
+                >
+                  <Calendar size={16} color={mutedColor} />
+                  <Text className="text-base text-foreground">
+                    {formatDate(endDate)}
+                  </Text>
+                </Pressable>
+                {showEndPicker && (
+                  <DateTimePicker
+                    value={endDate}
+                    mode="date"
+                    minimumDate={startDate}
+                    display={Platform.OS === "ios" ? "spinner" : "default"}
+                    onChange={(_, date) => {
+                      setShowEndPicker(Platform.OS === "ios");
+                      if (date) setEndDate(date);
+                    }}
+                  />
+                )}
+              </View>
+            </View>
+
+            <Button
+              label="Save Changes"
+              onPress={() => editMutation.mutate()}
+              loading={editMutation.isPending}
+              disabled={!title.trim()}
             />
           </View>
         </View>

--- a/apps/mobile/src/app/trip/new.tsx
+++ b/apps/mobile/src/app/trip/new.tsx
@@ -1,12 +1,14 @@
+import DateTimePicker from "@react-native-community/datetimepicker";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { MapPin, Search } from "lucide-react-native";
+import { Calendar, ChevronLeft, MapPin, Search, X } from "lucide-react-native";
 import { useUnstableNativeVariable } from "nativewind";
 import { useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import {
   ActivityIndicator,
+  Platform,
   Pressable,
   Text,
   TextInput,
@@ -17,15 +19,16 @@ import { client } from "@/api/client";
 import { Button } from "@/components/shared/Button";
 import { ErrorBanner } from "@/components/shared/ErrorBanner";
 import { Screen } from "@/components/shared/Screen";
+import { formatDate, toDateOnly } from "@/lib/utils";
 
 const tripSchema = z
   .object({
     destinationId: z.string().min(1, "Please select a destination"),
     title: z.string().min(1, "Title is required").max(100),
-    startDate: z.string().min(1, "Start date is required"),
-    endDate: z.string().min(1, "End date is required"),
+    startDate: z.date({ required_error: "Start date is required" }),
+    endDate: z.date({ required_error: "End date is required" }),
   })
-  .refine((d) => new Date(d.endDate) >= new Date(d.startDate), {
+  .refine((d) => d.endDate >= d.startDate, {
     message: "End date must be on or after start date",
     path: ["endDate"],
   });
@@ -44,25 +47,33 @@ export default function NewTripScreen() {
   const queryClient = useQueryClient();
   const mutedFg = useUnstableNativeVariable("--muted-foreground");
   const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
+  const foreground = useUnstableNativeVariable("--foreground");
+  const iconColor = foreground ? `hsl(${foreground})` : undefined;
 
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedDest, setSelectedDest] = useState<Destination | null>(null);
   const [showResults, setShowResults] = useState(false);
+  const [showStartPicker, setShowStartPicker] = useState(false);
+  const [showEndPicker, setShowEndPicker] = useState(false);
 
   const {
     control,
     handleSubmit,
     setValue,
+    watch,
     formState: { errors },
   } = useForm<TripValues>({
     resolver: zodResolver(tripSchema),
     defaultValues: {
       destinationId: "",
       title: "",
-      startDate: "",
-      endDate: "",
+      startDate: undefined,
+      endDate: undefined,
     },
   });
+
+  const startDate = watch("startDate");
+  const endDate = watch("endDate");
 
   const destQuery = useQuery({
     queryKey: ["destinations", searchQuery],
@@ -81,8 +92,8 @@ export default function NewTripScreen() {
       const res = await client.api.v1.trips.post({
         destinationId: values.destinationId,
         title: values.title,
-        startDate: new Date(values.startDate).toISOString(),
-        endDate: new Date(values.endDate).toISOString(),
+        startDate: values.startDate.toISOString(),
+        endDate: values.endDate.toISOString(),
       });
       if (res.error) throw new Error("Failed to create trip");
       return res.data;
@@ -102,11 +113,22 @@ export default function NewTripScreen() {
     setShowResults(false);
   };
 
+  const clearDestination = () => {
+    setSelectedDest(null);
+    setValue("destinationId", "");
+    setSearchQuery("");
+  };
+
   return (
     <Screen scrollable>
       <View className="gap-6">
+        {/* Header */}
         <View className="flex-row items-center gap-3">
-          <Pressable onPress={() => router.back()} className="active:opacity-80">
+          <Pressable
+            onPress={() => router.back()}
+            className="flex-row items-center gap-1 active:opacity-80"
+          >
+            <ChevronLeft size={20} color={iconColor} />
             <Text className="text-base font-medium text-primary">Cancel</Text>
           </Pressable>
           <Text className="flex-1 text-center text-lg font-bold text-foreground">
@@ -115,68 +137,82 @@ export default function NewTripScreen() {
           <View className="w-14" />
         </View>
 
-        <ErrorBanner
-          message={createMutation.error?.message ?? null}
-        />
+        <ErrorBanner message={createMutation.error?.message ?? null} />
 
-        {/* Destination search */}
-        <View className="gap-2">
-          <Text className="text-sm font-medium text-foreground">Destination</Text>
-          <View className="flex-row items-center rounded-xl border border-border bg-card px-3">
-            <Search size={18} color={mutedColor} />
-            <TextInput
-              className="ml-2 flex-1 py-3 text-base text-foreground"
-              placeholder="Search cities..."
-              placeholderTextColor={mutedColor}
-              value={searchQuery}
-              onChangeText={(t) => {
-                setSearchQuery(t);
-                setShowResults(true);
-                if (selectedDest && t !== `${selectedDest.name}, ${selectedDest.country}`) {
-                  setSelectedDest(null);
-                  setValue("destinationId", "");
-                }
-              }}
-            />
-          </View>
-          {errors.destinationId && (
-            <Text className="text-sm text-destructive">
-              {errors.destinationId.message}
-            </Text>
-          )}
-
-          {showResults && searchQuery.length >= 2 && (
-            <View className="rounded-xl border border-border bg-card">
-              {destQuery.isLoading && (
-                <View className="items-center py-4">
-                  <ActivityIndicator />
-                </View>
-              )}
-              {destQuery.data?.destinations?.map((dest) => (
-                <Pressable
-                  key={dest.id}
-                  onPress={() => selectDestination(dest as Destination)}
-                  className="flex-row items-center gap-3 border-b border-border px-4 py-3 last:border-b-0 active:bg-muted"
-                >
-                  <MapPin size={18} color={mutedColor} />
-                  <View>
-                    <Text className="text-base font-medium text-foreground">
-                      {dest.name}
-                    </Text>
-                    <Text className="text-sm text-muted-foreground">
-                      {(dest as Destination).country}
-                    </Text>
-                  </View>
-                </Pressable>
-              ))}
-              {destQuery.data?.destinations?.length === 0 && (
-                <Text className="px-4 py-3 text-sm text-muted-foreground">
-                  No destinations found
+        {/* Selected destination chip */}
+        {selectedDest ? (
+          <View className="gap-2">
+            <Text className="text-sm font-medium text-foreground">Destination</Text>
+            <View className="flex-row items-center gap-3 rounded-xl border border-primary/30 bg-primary/10 px-4 py-3">
+              <MapPin size={18} color={iconColor} />
+              <View className="flex-1">
+                <Text className="text-base font-semibold text-foreground">
+                  {selectedDest.name}
                 </Text>
-              )}
+                <Text className="text-sm text-muted-foreground">
+                  {selectedDest.country}
+                </Text>
+              </View>
+              <Pressable onPress={clearDestination} className="active:opacity-80">
+                <X size={18} color={mutedColor} />
+              </Pressable>
             </View>
-          )}
-        </View>
+          </View>
+        ) : (
+          <View className="gap-2">
+            <Text className="text-sm font-medium text-foreground">Destination</Text>
+            <View className="flex-row items-center rounded-xl border border-border bg-card px-3">
+              <Search size={18} color={mutedColor} />
+              <TextInput
+                className="ml-2 flex-1 py-3 text-base text-foreground"
+                placeholder="Search cities..."
+                placeholderTextColor={mutedColor}
+                value={searchQuery}
+                onChangeText={(t) => {
+                  setSearchQuery(t);
+                  setShowResults(true);
+                }}
+              />
+            </View>
+            {errors.destinationId && (
+              <Text className="text-sm text-destructive">
+                {errors.destinationId.message}
+              </Text>
+            )}
+
+            {showResults && searchQuery.length >= 2 && (
+              <View className="rounded-xl border border-border bg-card">
+                {destQuery.isLoading && (
+                  <View className="items-center py-4">
+                    <ActivityIndicator />
+                  </View>
+                )}
+                {destQuery.data?.destinations?.map((dest) => (
+                  <Pressable
+                    key={dest.id}
+                    onPress={() => selectDestination(dest as Destination)}
+                    className="flex-row items-center gap-3 border-b border-border px-4 py-3 last:border-b-0 active:bg-muted"
+                  >
+                    <MapPin size={18} color={mutedColor} />
+                    <View>
+                      <Text className="text-base font-medium text-foreground">
+                        {dest.name}
+                      </Text>
+                      <Text className="text-sm text-muted-foreground">
+                        {(dest as Destination).country}
+                      </Text>
+                    </View>
+                  </Pressable>
+                ))}
+                {destQuery.data?.destinations?.length === 0 && (
+                  <Text className="px-4 py-3 text-sm text-muted-foreground">
+                    No destinations found
+                  </Text>
+                )}
+              </View>
+            )}
+          </View>
+        )}
 
         {/* Title */}
         <View className="gap-2">
@@ -204,19 +240,32 @@ export default function NewTripScreen() {
         <View className="flex-row gap-3">
           <View className="flex-1 gap-2">
             <Text className="text-sm font-medium text-foreground">Start Date</Text>
-            <Controller
-              control={control}
-              name="startDate"
-              render={({ field: { onChange, value } }) => (
-                <TextInput
-                  className="rounded-xl border border-border bg-card px-4 py-3 text-base text-foreground"
-                  placeholder="YYYY-MM-DD"
-                  placeholderTextColor={mutedColor}
-                  value={value}
-                  onChangeText={onChange}
-                />
-              )}
-            />
+            <Pressable
+              onPress={() => setShowStartPicker(true)}
+              className="flex-row items-center gap-2 rounded-xl border border-border bg-card px-4 py-3"
+            >
+              <Calendar size={16} color={mutedColor} />
+              <Text className={`text-base ${startDate ? "text-foreground" : "text-muted-foreground"}`}>
+                {startDate ? formatDate(startDate) : "Select"}
+              </Text>
+            </Pressable>
+            {showStartPicker && (
+              <DateTimePicker
+                value={startDate ?? new Date()}
+                mode="date"
+                minimumDate={new Date()}
+                display={Platform.OS === "ios" ? "spinner" : "default"}
+                onChange={(_, date) => {
+                  setShowStartPicker(Platform.OS === "ios");
+                  if (date) {
+                    setValue("startDate", date, { shouldValidate: true });
+                    if (endDate && date > endDate) {
+                      setValue("endDate", date, { shouldValidate: true });
+                    }
+                  }
+                }}
+              />
+            )}
             {errors.startDate && (
               <Text className="text-sm text-destructive">
                 {errors.startDate.message}
@@ -226,19 +275,29 @@ export default function NewTripScreen() {
 
           <View className="flex-1 gap-2">
             <Text className="text-sm font-medium text-foreground">End Date</Text>
-            <Controller
-              control={control}
-              name="endDate"
-              render={({ field: { onChange, value } }) => (
-                <TextInput
-                  className="rounded-xl border border-border bg-card px-4 py-3 text-base text-foreground"
-                  placeholder="YYYY-MM-DD"
-                  placeholderTextColor={mutedColor}
-                  value={value}
-                  onChangeText={onChange}
-                />
-              )}
-            />
+            <Pressable
+              onPress={() => setShowEndPicker(true)}
+              className="flex-row items-center gap-2 rounded-xl border border-border bg-card px-4 py-3"
+            >
+              <Calendar size={16} color={mutedColor} />
+              <Text className={`text-base ${endDate ? "text-foreground" : "text-muted-foreground"}`}>
+                {endDate ? formatDate(endDate) : "Select"}
+              </Text>
+            </Pressable>
+            {showEndPicker && (
+              <DateTimePicker
+                value={endDate ?? startDate ?? new Date()}
+                mode="date"
+                minimumDate={startDate ?? new Date()}
+                display={Platform.OS === "ios" ? "spinner" : "default"}
+                onChange={(_, date) => {
+                  setShowEndPicker(Platform.OS === "ios");
+                  if (date) {
+                    setValue("endDate", date, { shouldValidate: true });
+                  }
+                }}
+              />
+            )}
             {errors.endDate && (
               <Text className="text-sm text-destructive">
                 {errors.endDate.message}
@@ -246,6 +305,16 @@ export default function NewTripScreen() {
             )}
           </View>
         </View>
+
+        {/* Trip summary preview */}
+        {selectedDest && startDate && endDate && (
+          <View className="rounded-xl border border-border bg-card/50 px-4 py-3">
+            <Text className="text-sm text-muted-foreground">
+              {Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1} days
+              {" "}in {selectedDest.name}, {selectedDest.country}
+            </Text>
+          </View>
+        )}
 
         <Button
           label="Create Trip"

--- a/apps/mobile/src/lib/utils.ts
+++ b/apps/mobile/src/lib/utils.ts
@@ -4,3 +4,35 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** Safely convert a Date or ISO string to an ISO string. */
+export function toISO(value: string | Date): string {
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}
+
+/** Extract the YYYY-MM-DD portion from a Date or ISO string. */
+export function toDateOnly(value: string | Date): string {
+  return toISO(value).split("T")[0];
+}
+
+export function formatDate(value: string | Date): string {
+  return new Date(value).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function formatDateRange(start: string | Date, end: string | Date): string {
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+  return `${new Date(start).toLocaleDateString("en-US", opts)} – ${new Date(end).toLocaleDateString("en-US", opts)}`;
+}
+
+export function daysUntil(date: string | Date): number {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const target = new Date(date);
+  target.setHours(0, 0, 0, 0);
+  return Math.ceil((target.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: ^3.0.1
         version: 3.0.1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@react-native-community/datetimepicker':
+        specifier: 8.6.0
+        version: 8.6.0(expo@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@react-native-google-signin/google-signin':
         specifier: ^16.1.2
         version: 16.1.2(expo@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -1695,6 +1698,19 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  '@react-native-community/datetimepicker@8.6.0':
+    resolution: {integrity: sha512-yxPSqNfxgpGaqHQIpatqe6ykeBdU/1pdsk/G3x01mY2bpTflLpmVTLqFSJYd3MiZzxNZcMs/j1dQakUczSjcYA==}
+    peerDependencies:
+      expo: '>=52.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native-google-signin/google-signin@16.1.2':
     resolution: {integrity: sha512-1hf4pRmpnS5t0dHtqU72Q1FmWzsCZR2Sm3uVQbbfMKeNPl5TKjpAsP6F8QTZ9L+Q6Cnn9tL9BXpDCb1nyutdCQ==}
@@ -6437,6 +6453,14 @@ snapshots:
       idb: 8.0.3
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+
+  '@react-native-community/datetimepicker@8.6.0(expo@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      invariant: 2.2.4
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+    optionalDependencies:
+      expo: 55.0.4(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.4)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   '@react-native-google-signin/google-signin@16.1.2(expo@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:


### PR DESCRIPTION
Fix trip.startDate.split crash (Date objects from Eden Treaty). Add shared date utils. Replace text date inputs with native date pickers on trip creation and itinerary item modal. Add trip editing modal on detail screen. Wire up Explore tab to real destination/places API. Add pull-to-refresh on Home. Group trips by status with countdown badges. Add progress bars for itinerary completion. Install @react-native-community/datetimepicker.

Made-with: Cursor