### PR TITLE
feat: offline pack download, network status, pack version check, back…

### DIFF
--- a/apps/api/src/modules/itinerary/service.test.ts
+++ b/apps/api/src/modules/itinerary/service.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { prisma } from "@repo/db";
+
+process.env.NODE_ENV = "development";
+process.env.JWT_ACCESS_SECRET ??= "test_access_secret_1234567890";
+process.env.JWT_REFRESH_SECRET ??= "test_refresh_secret_1234567890";
+
+const { itineraryService } = await import("./service");
+const { tripService } = await import("../trip/service");
+const { authService } = await import("../auth/service");
+
+const runId = `itin_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const createdUserIds = new Set<string>();
+const createdTripIds = new Set<string>();
+
+let testUserId: string;
+let testTripId: string;
+
+async function setup() {
+  const user = await authService.register(
+    `${runId}@test.local`,
+    "Password456!",
+    "Itinerary Tester",
+    `${runId}_user`
+  );
+  createdUserIds.add(user.user.id);
+  testUserId = user.user.id;
+
+  const dest = await prisma.destination.findFirst({ select: { id: true } });
+  if (!dest) throw new Error("No destinations seeded");
+
+  const trip = await tripService.create(testUserId, {
+    destinationId: dest.id,
+    title: "Itinerary Test Trip",
+    startDate: "2026-06-01T00:00:00.000Z",
+    endDate: "2026-06-07T00:00:00.000Z",
+  });
+  createdTripIds.add(trip.id);
+  testTripId = trip.id;
+}
+
+afterEach(async () => {
+  for (const tripId of createdTripIds) {
+    await prisma.itineraryItem.deleteMany({ where: { tripId } });
+  }
+  await prisma.trip.deleteMany({
+    where: { id: { in: [...createdTripIds] } },
+  });
+  createdTripIds.clear();
+
+  await prisma.user.deleteMany({
+    where: { id: { in: [...createdUserIds] } },
+  });
+  createdUserIds.clear();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("itineraryService", () => {
+  test("create and list items", async () => {
+    await setup();
+
+    const item = await itineraryService.create(testTripId, testUserId, {
+      title: "Visit temple",
+      date: "2026-06-02T00:00:00.000Z",
+    });
+
+    expect(item.title).toBe("Visit temple");
+    expect(item.tripId).toBe(testTripId);
+
+    const items = await itineraryService.listByTrip(testTripId, testUserId);
+    expect(items.length).toBe(1);
+    expect(items[0]!.title).toBe("Visit temple");
+  });
+
+  test("update item title and isDone", async () => {
+    await setup();
+
+    const item = await itineraryService.create(testTripId, testUserId, {
+      title: "Original",
+      date: "2026-06-03T00:00:00.000Z",
+    });
+
+    const updated = await itineraryService.update(item.id, testUserId, {
+      title: "Updated",
+      isDone: true,
+    });
+
+    expect(updated!.title).toBe("Updated");
+    expect(updated!.isDone).toBe(true);
+  });
+
+  test("delete item removes it", async () => {
+    await setup();
+
+    const item = await itineraryService.create(testTripId, testUserId, {
+      title: "Removable",
+      date: "2026-06-04T00:00:00.000Z",
+    });
+
+    await itineraryService.remove(item.id, testUserId);
+
+    const items = await itineraryService.listByTrip(testTripId, testUserId);
+    expect(items.length).toBe(0);
+  });
+
+  test("auto-calculates order for new items on same date", async () => {
+    await setup();
+
+    const item1 = await itineraryService.create(testTripId, testUserId, {
+      title: "First",
+      date: "2026-06-05T00:00:00.000Z",
+    });
+    const item2 = await itineraryService.create(testTripId, testUserId, {
+      title: "Second",
+      date: "2026-06-05T00:00:00.000Z",
+    });
+
+    expect(item1.order).toBe(0);
+    expect(item2.order).toBe(1);
+  });
+
+  test("reorder changes item order", async () => {
+    await setup();
+
+    const item1 = await itineraryService.create(testTripId, testUserId, {
+      title: "A",
+      date: "2026-06-06T00:00:00.000Z",
+    });
+    const item2 = await itineraryService.create(testTripId, testUserId, {
+      title: "B",
+      date: "2026-06-06T00:00:00.000Z",
+    });
+
+    await itineraryService.reorder(testTripId, testUserId, [
+      { id: item1.id, order: 1 },
+      { id: item2.id, order: 0 },
+    ]);
+
+    const items = await itineraryService.listByTrip(testTripId, testUserId);
+    const a = items.find((i) => i.title === "A");
+    const b = items.find((i) => i.title === "B");
+    expect(b!.order).toBe(0);
+    expect(a!.order).toBe(1);
+  });
+});

--- a/apps/api/src/modules/trip/service.test.ts
+++ b/apps/api/src/modules/trip/service.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { prisma } from "@repo/db";
+
+process.env.NODE_ENV = "development";
+process.env.JWT_ACCESS_SECRET ??= "test_access_secret_1234567890";
+process.env.JWT_REFRESH_SECRET ??= "test_refresh_secret_1234567890";
+
+const { tripService } = await import("./service");
+const { authService } = await import("../auth/service");
+
+const runId = `trip_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const createdUserIds = new Set<string>();
+const createdTripIds = new Set<string>();
+
+let testUserId: string;
+let testDestinationId: string;
+
+async function setupUser() {
+  const result = await authService.register(
+    `${runId}@test.local`,
+    "Password456!",
+    "Trip Tester",
+    `${runId}_user`
+  );
+  createdUserIds.add(result.user.id);
+  testUserId = result.user.id;
+}
+
+async function getDestination() {
+  const dest = await prisma.destination.findFirst({ select: { id: true } });
+  if (!dest) throw new Error("No destinations seeded — run db:seed first");
+  testDestinationId = dest.id;
+}
+
+afterEach(async () => {
+  if (createdTripIds.size > 0) {
+    await prisma.itineraryItem.deleteMany({
+      where: { tripId: { in: [...createdTripIds] } },
+    });
+    await prisma.trip.deleteMany({
+      where: { id: { in: [...createdTripIds] } },
+    });
+    createdTripIds.clear();
+  }
+});
+
+afterAll(async () => {
+  if (createdUserIds.size > 0) {
+    await prisma.user.deleteMany({
+      where: { id: { in: [...createdUserIds] } },
+    });
+  }
+  await prisma.$disconnect();
+});
+
+describe("tripService", () => {
+  test("create trip and list it", async () => {
+    await setupUser();
+    await getDestination();
+
+    const trip = await tripService.create(testUserId, {
+      destinationId: testDestinationId,
+      title: "Test Trip",
+      startDate: "2026-06-01T00:00:00.000Z",
+      endDate: "2026-06-07T00:00:00.000Z",
+    });
+
+    createdTripIds.add(trip.id);
+
+    expect(trip.title).toBe("Test Trip");
+    expect(trip.destination.id).toBe(testDestinationId);
+
+    const trips = await tripService.list(testUserId);
+    expect(trips.some((t) => t.id === trip.id)).toBe(true);
+  });
+
+  test("getById returns the correct trip", async () => {
+    await setupUser();
+    await getDestination();
+
+    const trip = await tripService.create(testUserId, {
+      destinationId: testDestinationId,
+      title: "Getable Trip",
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-05T00:00:00.000Z",
+    });
+    createdTripIds.add(trip.id);
+
+    const fetched = await tripService.getById(trip.id, testUserId);
+    expect(fetched.title).toBe("Getable Trip");
+  });
+
+  test("update changes the trip title", async () => {
+    await setupUser();
+    await getDestination();
+
+    const trip = await tripService.create(testUserId, {
+      destinationId: testDestinationId,
+      title: "Old Title",
+      startDate: "2026-08-01T00:00:00.000Z",
+      endDate: "2026-08-05T00:00:00.000Z",
+    });
+    createdTripIds.add(trip.id);
+
+    const updated = await tripService.update(trip.id, testUserId, {
+      title: "New Title",
+    });
+    expect(updated.title).toBe("New Title");
+  });
+
+  test("delete removes the trip", async () => {
+    await setupUser();
+    await getDestination();
+
+    const trip = await tripService.create(testUserId, {
+      destinationId: testDestinationId,
+      title: "Deletable Trip",
+      startDate: "2026-09-01T00:00:00.000Z",
+      endDate: "2026-09-05T00:00:00.000Z",
+    });
+    createdTripIds.add(trip.id);
+
+    await tripService.remove(trip.id, testUserId);
+
+    await expect(tripService.getById(trip.id, testUserId)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+    createdTripIds.delete(trip.id);
+  });
+
+  test("endDate before startDate throws validation error", async () => {
+    await setupUser();
+    await getDestination();
+
+    await expect(
+      tripService.create(testUserId, {
+        destinationId: testDestinationId,
+        title: "Bad Dates",
+        startDate: "2026-06-10T00:00:00.000Z",
+        endDate: "2026-06-05T00:00:00.000Z",
+      })
+    ).rejects.toMatchObject({ statusCode: 422 });
+  });
+});

--- a/apps/api/src/modules/user/service.test.ts
+++ b/apps/api/src/modules/user/service.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { prisma } from "@repo/db";
+
+process.env.NODE_ENV = "development";
+process.env.JWT_ACCESS_SECRET ??= "test_access_secret_1234567890";
+process.env.JWT_REFRESH_SECRET ??= "test_refresh_secret_1234567890";
+
+const { userService } = await import("./service");
+const { authService } = await import("../auth/service");
+
+const runId = `user_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const createdUserIds = new Set<string>();
+
+afterEach(async () => {
+  if (createdUserIds.size > 0) {
+    await prisma.user.deleteMany({
+      where: { id: { in: [...createdUserIds] } },
+    });
+    createdUserIds.clear();
+  }
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("userService", () => {
+  test("getProfile returns the user", async () => {
+    const result = await authService.register(
+      `${runId}_get@test.local`,
+      "Password456!",
+      "Profile User",
+      `${runId}_get`
+    );
+    createdUserIds.add(result.user.id);
+
+    const profile = await userService.getProfile(result.user.id);
+    expect(profile.email).toBe(`${runId}_get@test.local`);
+    expect(profile.name).toBe("Profile User");
+  });
+
+  test("updateProfile changes name and username", async () => {
+    const result = await authService.register(
+      `${runId}_upd@test.local`,
+      "Password456!",
+      "Old Name",
+      `${runId}_upd`
+    );
+    createdUserIds.add(result.user.id);
+
+    const updated = await userService.updateProfile(result.user.id, {
+      name: "New Name",
+      username: `${runId}_upd_new`,
+    });
+
+    expect(updated.name).toBe("New Name");
+    expect(updated.username).toBe(`${runId}_upd_new`);
+  });
+
+  test("updateProfile rejects duplicate username", async () => {
+    const r1 = await authService.register(
+      `${runId}_dup1@test.local`,
+      "Password456!",
+      "User One",
+      `${runId}_dup1`
+    );
+    createdUserIds.add(r1.user.id);
+
+    const r2 = await authService.register(
+      `${runId}_dup2@test.local`,
+      "Password456!",
+      "User Two",
+      `${runId}_dup2`
+    );
+    createdUserIds.add(r2.user.id);
+
+    await expect(
+      userService.updateProfile(r2.user.id, { username: `${runId}_dup1` })
+    ).rejects.toMatchObject({ statusCode: 409, code: "CONFLICT" });
+  });
+
+  test("getProfile throws for non-existent user", async () => {
+    await expect(
+      userService.getProfile("00000000-0000-0000-0000-000000000000")
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -18,6 +18,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "^3.0.1",
     "@react-native-community/datetimepicker": "8.6.0",
+    "@react-native-community/netinfo": "11.5.2",
     "@react-native-google-signin/google-signin": "^16.1.2",
     "@react-navigation/bottom-tabs": "^7.7.3",
     "@react-navigation/elements": "^2.8.1",

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,9 +1,11 @@
 import { Tabs } from "expo-router";
 import { BottomTabBar } from "@/components/shared/BottomTabBar";
 import { useAuthGuard } from "@/hooks/useAuthGuard";
+import { usePackVersionCheck } from "@/hooks/usePackVersionCheck";
 
 export default function TabsLayout() {
   const isAuthenticated = useAuthGuard();
+  usePackVersionCheck();
 
   if (!isAuthenticated) {
     return null;

--- a/apps/mobile/src/app/(tabs)/explore.tsx
+++ b/apps/mobile/src/app/(tabs)/explore.tsx
@@ -62,9 +62,13 @@ function CategoryBadge({ category }: { category: string }) {
 function PlaceCard({ place }: { place: Place }) {
   const mutedFg = useUnstableNativeVariable("--muted-foreground");
   const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
+  const router = useRouter();
 
   return (
-    <View className="mr-3 w-56 rounded-xl border border-border bg-card p-3">
+    <Pressable
+      onPress={() => router.push(`/place/${place.id}` as never)}
+      className="mr-3 w-56 rounded-xl border border-border bg-card p-3 active:opacity-90"
+    >
       <View className="flex-row items-center justify-between">
         <CategoryBadge category={place.category} />
         {place.rating && (
@@ -89,7 +93,7 @@ function PlaceCard({ place }: { place: Place }) {
           Curated pick
         </Text>
       )}
-    </View>
+    </Pressable>
   );
 }
 

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -5,14 +5,26 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useColorScheme } from "nativewind";
+import { useEffect } from "react";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { client, EdenProvider } from "@/api/client";
+import { OfflineBanner } from "@/components/shared/OfflineBanner";
 import { NAV_THEME } from "@/lib/theme";
+import { useNetworkStore } from "@/store/networkStore";
+import { useOfflineStore } from "@/store/offlineStore";
 
 const queryClient = new QueryClient();
 
 export default function RootLayout() {
   const { colorScheme } = useColorScheme();
+  const startListening = useNetworkStore((s) => s.startListening);
+  const hydrateOffline = useOfflineStore((s) => s.hydrate);
+
+  useEffect(() => {
+    const unsubscribe = startListening();
+    hydrateOffline();
+    return unsubscribe;
+  }, [startListening, hydrateOffline]);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -20,6 +32,7 @@ export default function RootLayout() {
         <KeyboardProvider>
           <ThemeProvider value={NAV_THEME[colorScheme ?? "light"]}>
             <StatusBar style={colorScheme === "dark" ? "light" : "dark"} />
+            <OfflineBanner />
             <Stack screenOptions={{ headerShown: false }} />
             <PortalHost />
           </ThemeProvider>

--- a/apps/mobile/src/app/place/[id].tsx
+++ b/apps/mobile/src/app/place/[id].tsx
@@ -1,0 +1,209 @@
+import { useQuery } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import {
+  ChevronLeft,
+  ExternalLink,
+  Globe,
+  MapPin,
+  Phone,
+  Star,
+} from "lucide-react-native";
+import { useUnstableNativeVariable } from "nativewind";
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  Text,
+  View,
+} from "react-native";
+import { client } from "@/api/client";
+import { Screen } from "@/components/shared/Screen";
+
+type PlaceDetail = {
+  id: string;
+  name: string;
+  slug: string;
+  category: string;
+  description: string | null;
+  latitude: number;
+  longitude: number;
+  address: string | null;
+  imageUrl: string | null;
+  rating: number | null;
+  isCurated: boolean;
+  isFeatured: boolean;
+  websiteUrl: string | null;
+  phoneNumber: string | null;
+  priceLevel: number | null;
+  reviewCount: number | null;
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ATTRACTION: "Attraction",
+  RESTAURANT: "Restaurant",
+  HOTEL: "Hotel",
+  SHOPPING: "Shopping",
+  NIGHTLIFE: "Nightlife",
+  TRANSPORT: "Transport",
+  OTHER: "Other",
+};
+
+const PRICE_LABELS = ["", "$", "$$", "$$$", "$$$$"];
+
+export default function PlaceDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const mutedFg = useUnstableNativeVariable("--muted-foreground");
+  const mutedColor = mutedFg ? `hsl(${mutedFg})` : "#9CA3AF";
+  const foreground = useUnstableNativeVariable("--foreground");
+  const iconColor = foreground ? `hsl(${foreground})` : undefined;
+
+  const placeQuery = useQuery({
+    queryKey: ["place", id],
+    queryFn: async () => {
+      const res = await client.api.v1.places({ id: id! }).get();
+      if (res.error) throw new Error("Failed to load place");
+      return res.data;
+    },
+    enabled: !!id,
+  });
+
+  const place = placeQuery.data?.place as PlaceDetail | undefined;
+
+  if (placeQuery.isLoading) {
+    return (
+      <Screen>
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator />
+        </View>
+      </Screen>
+    );
+  }
+
+  if (!place) {
+    return (
+      <Screen>
+        <View className="flex-1 items-center justify-center gap-2">
+          <Text className="text-lg font-semibold text-foreground">Place not found</Text>
+          <Pressable onPress={() => router.back()}>
+            <Text className="text-primary">Go back</Text>
+          </Pressable>
+        </View>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen scrollable contentClassName="pb-10">
+      <View className="gap-5">
+        {/* Header */}
+        <Pressable
+          onPress={() => router.back()}
+          className="flex-row items-center gap-1 active:opacity-80"
+        >
+          <ChevronLeft size={20} color={iconColor} />
+          <Text className="text-base font-medium text-primary">Back</Text>
+        </Pressable>
+
+        {/* Title + category */}
+        <View className="gap-2">
+          <View className="flex-row items-center gap-2">
+            <View className="rounded-full bg-primary/10 px-2.5 py-1">
+              <Text className="text-xs font-semibold text-primary">
+                {CATEGORY_LABELS[place.category] ?? place.category}
+              </Text>
+            </View>
+            {place.isCurated && (
+              <View className="rounded-full bg-chart-2/10 px-2.5 py-1">
+                <Text className="text-xs font-semibold text-chart-2">Curated</Text>
+              </View>
+            )}
+            {place.isFeatured && (
+              <View className="rounded-full bg-amber-500/10 px-2.5 py-1">
+                <Text className="text-xs font-semibold text-amber-600">Featured</Text>
+              </View>
+            )}
+          </View>
+
+          <Text className="text-2xl font-bold text-foreground">{place.name}</Text>
+
+          {/* Rating + reviews */}
+          <View className="flex-row items-center gap-3">
+            {place.rating && (
+              <View className="flex-row items-center gap-1">
+                <Star size={16} color="#F59E0B" fill="#F59E0B" />
+                <Text className="text-base font-semibold text-foreground">
+                  {place.rating.toFixed(1)}
+                </Text>
+                {place.reviewCount && (
+                  <Text className="text-sm text-muted-foreground">
+                    ({place.reviewCount.toLocaleString()} reviews)
+                  </Text>
+                )}
+              </View>
+            )}
+            {place.priceLevel && place.priceLevel > 0 && (
+              <Text className="text-sm font-medium text-muted-foreground">
+                {PRICE_LABELS[place.priceLevel]}
+              </Text>
+            )}
+          </View>
+        </View>
+
+        {/* Description */}
+        {place.description && (
+          <View className="gap-1">
+            <Text className="text-sm font-semibold text-foreground">About</Text>
+            <Text className="text-base leading-6 text-muted-foreground">
+              {place.description}
+            </Text>
+          </View>
+        )}
+
+        {/* Details */}
+        <View className="gap-3 rounded-2xl border border-border bg-card p-4">
+          {place.address && (
+            <View className="flex-row items-start gap-3">
+              <MapPin size={18} color={mutedColor} className="mt-0.5" />
+              <Text className="flex-1 text-base text-foreground">{place.address}</Text>
+            </View>
+          )}
+
+          {place.phoneNumber && (
+            <Pressable
+              onPress={() => Linking.openURL(`tel:${place.phoneNumber}`)}
+              className="flex-row items-center gap-3 active:opacity-80"
+            >
+              <Phone size={18} color={mutedColor} />
+              <Text className="text-base text-primary">{place.phoneNumber}</Text>
+            </Pressable>
+          )}
+
+          {place.websiteUrl && (
+            <Pressable
+              onPress={() => Linking.openURL(place.websiteUrl!)}
+              className="flex-row items-center gap-3 active:opacity-80"
+            >
+              <Globe size={18} color={mutedColor} />
+              <Text className="flex-1 text-base text-primary" numberOfLines={1}>
+                {place.websiteUrl.replace(/^https?:\/\//, "")}
+              </Text>
+              <ExternalLink size={14} color={mutedColor} />
+            </Pressable>
+          )}
+
+          {!place.address && !place.phoneNumber && !place.websiteUrl && (
+            <Text className="text-sm text-muted-foreground">No additional details available</Text>
+          )}
+        </View>
+
+        {/* Coordinates */}
+        <View className="rounded-xl border border-border bg-muted/30 px-4 py-3">
+          <Text className="text-xs text-muted-foreground">
+            Coordinates: {place.latitude.toFixed(5)}, {place.longitude.toFixed(5)}
+          </Text>
+        </View>
+      </View>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/trip/[id].tsx
+++ b/apps/mobile/src/app/trip/[id].tsx
@@ -7,8 +7,10 @@ import {
   ChevronLeft,
   Circle,
   Clock,
+  Download,
   Edit3,
   MapPin,
+  PackageCheck,
   Plus,
   Trash2,
 } from "lucide-react-native";
@@ -29,6 +31,7 @@ import { client } from "@/api/client";
 import { Button } from "@/components/shared/Button";
 import { Screen } from "@/components/shared/Screen";
 import { formatDate, toDateOnly } from "@/lib/utils";
+import { useOfflineStore } from "@/store/offlineStore";
 
 type ItineraryItem = {
   id: string;
@@ -127,6 +130,37 @@ export default function TripDetailScreen() {
   const doneCount = items.filter((i) => i.isDone).length;
   const progress = items.length > 0 ? doneCount / items.length : 0;
 
+  const destId = trip?.destination?.id;
+  const isPackDownloaded = useOfflineStore((s) => destId ? s.isDownloaded(destId) : false);
+  const packMeta = useOfflineStore((s) => destId ? s.getPackMeta(destId) : undefined);
+  const downloading = useOfflineStore((s) => s.downloading);
+  const savePack = useOfflineStore((s) => s.savePack);
+  const setDownloading = useOfflineStore((s) => s.setDownloading);
+
+  const downloadPack = useMutation({
+    mutationFn: async () => {
+      if (!destId) throw new Error("No destination");
+      setDownloading(destId);
+      const res = await client.api.v1["offline-pack"]({ destinationId: destId }).get();
+      if (res.error) throw new Error("Failed to download pack");
+      return res.data;
+    },
+    onSuccess: (data) => {
+      if (!destId || !trip || !data) return;
+      savePack({
+        destinationId: destId,
+        destinationName: trip.destination.name,
+        country: trip.destination.countryCode,
+        countryCode: trip.destination.countryCode,
+        packVersion: (data as any).packVersion ?? 1,
+        downloadedAt: new Date().toISOString(),
+        placesCount: ((data as any).places ?? []).length,
+        phrasesCount: ((data as any).phrases ?? []).length,
+      }, data);
+    },
+    onError: () => setDownloading(null),
+  });
+
   if (tripQuery.isLoading) {
     return (
       <Screen>
@@ -212,6 +246,42 @@ export default function TripDetailScreen() {
                 style={{ width: `${progress * 100}%` }}
               />
             </View>
+          </View>
+        )}
+
+        {/* Offline pack */}
+        {trip && (
+          <View className="rounded-xl border border-border bg-card px-4 py-3">
+            {isPackDownloaded ? (
+              <View className="flex-row items-center gap-3">
+                <PackageCheck size={20} color="#22C55E" />
+                <View className="flex-1">
+                  <Text className="text-sm font-medium text-foreground">
+                    Offline pack downloaded
+                  </Text>
+                  <Text className="text-xs text-muted-foreground">
+                    {packMeta?.placesCount} places · {packMeta?.phrasesCount} phrases
+                  </Text>
+                </View>
+              </View>
+            ) : (
+              <Pressable
+                onPress={() => downloadPack.mutate()}
+                disabled={downloading === destId}
+                className="flex-row items-center gap-3 active:opacity-80"
+              >
+                <Download size={20} color={iconColor} />
+                <View className="flex-1">
+                  <Text className="text-sm font-medium text-foreground">
+                    {downloading === destId ? "Downloading..." : "Download Offline Pack"}
+                  </Text>
+                  <Text className="text-xs text-muted-foreground">
+                    Save places & phrases for offline use
+                  </Text>
+                </View>
+                {downloading === destId && <ActivityIndicator size="small" />}
+              </Pressable>
+            )}
           </View>
         )}
 

--- a/apps/mobile/src/components/shared/OfflineBanner.tsx
+++ b/apps/mobile/src/components/shared/OfflineBanner.tsx
@@ -1,0 +1,18 @@
+import { WifiOff } from "lucide-react-native";
+import { Text, View } from "react-native";
+import { useNetworkStore } from "@/store/networkStore";
+
+export function OfflineBanner() {
+  const isConnected = useNetworkStore((s) => s.isConnected);
+
+  if (isConnected) return null;
+
+  return (
+    <View className="flex-row items-center justify-center gap-2 bg-destructive/90 px-4 py-2">
+      <WifiOff size={14} color="white" />
+      <Text className="text-sm font-medium text-white">
+        You're offline — some features may be limited
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/hooks/usePackVersionCheck.ts
+++ b/apps/mobile/src/hooks/usePackVersionCheck.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+import { Alert } from "react-native";
+import { client } from "@/api/client";
+import { useNetworkStore } from "@/store/networkStore";
+import { useOfflineStore } from "@/store/offlineStore";
+
+export function usePackVersionCheck() {
+  const isConnected = useNetworkStore((s) => s.isConnected);
+  const packs = useOfflineStore((s) => s.packs);
+  const wasOffline = useRef(false);
+
+  useEffect(() => {
+    if (!isConnected) {
+      wasOffline.current = true;
+      return;
+    }
+
+    if (!wasOffline.current || packs.length === 0) return;
+    wasOffline.current = false;
+
+    (async () => {
+      for (const pack of packs) {
+        try {
+          const res = await client.api.v1
+            .destinations({ destId: pack.destinationId })
+            ["pack-version"].get();
+          if (res.error) continue;
+          const remote = (res.data as any)?.packVersion;
+          if (typeof remote === "number" && remote > pack.packVersion) {
+            Alert.alert(
+              "Update Available",
+              `A new offline pack is available for ${pack.destinationName}. Open the trip to update.`,
+              [{ text: "OK" }]
+            );
+          }
+        } catch {
+          // Non-critical — skip silently
+        }
+      }
+    })();
+  }, [isConnected, packs]);
+}

--- a/apps/mobile/src/store/networkStore.ts
+++ b/apps/mobile/src/store/networkStore.ts
@@ -1,0 +1,22 @@
+import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
+import { create } from "zustand";
+
+type NetworkState = {
+  isConnected: boolean;
+  isInternetReachable: boolean | null;
+  startListening: () => () => void;
+};
+
+export const useNetworkStore = create<NetworkState>((set) => ({
+  isConnected: true,
+  isInternetReachable: true,
+  startListening: () => {
+    const unsubscribe = NetInfo.addEventListener((state: NetInfoState) => {
+      set({
+        isConnected: state.isConnected ?? true,
+        isInternetReachable: state.isInternetReachable,
+      });
+    });
+    return unsubscribe;
+  },
+}));

--- a/apps/mobile/src/store/offlineStore.ts
+++ b/apps/mobile/src/store/offlineStore.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+import { storage } from "@/lib/storage";
+
+const OFFLINE_PACKS_KEY = "travel_companion_offline_packs";
+
+export type OfflinePack = {
+  destinationId: string;
+  destinationName: string;
+  country: string;
+  countryCode: string;
+  packVersion: number;
+  downloadedAt: string;
+  placesCount: number;
+  phrasesCount: number;
+};
+
+type OfflineState = {
+  packs: OfflinePack[];
+  downloading: string | null;
+  hydrated: boolean;
+  hydrate: () => Promise<void>;
+  savePack: (pack: OfflinePack, data: unknown) => Promise<void>;
+  removePack: (destinationId: string) => Promise<void>;
+  getPackData: (destinationId: string) => Promise<unknown | null>;
+  isDownloaded: (destinationId: string) => boolean;
+  getPackMeta: (destinationId: string) => OfflinePack | undefined;
+  setDownloading: (destinationId: string | null) => void;
+};
+
+export const useOfflineStore = create<OfflineState>((set, get) => ({
+  packs: [],
+  downloading: null,
+  hydrated: false,
+
+  hydrate: async () => {
+    try {
+      const raw = await storage.getItem(OFFLINE_PACKS_KEY);
+      if (raw) {
+        set({ packs: JSON.parse(raw), hydrated: true });
+      } else {
+        set({ hydrated: true });
+      }
+    } catch {
+      set({ hydrated: true });
+    }
+  },
+
+  savePack: async (pack, data) => {
+    const current = get().packs.filter((p) => p.destinationId !== pack.destinationId);
+    const updated = [...current, pack];
+    await storage.setItem(OFFLINE_PACKS_KEY, JSON.stringify(updated));
+    await storage.setItem(`offline_pack_${pack.destinationId}`, JSON.stringify(data));
+    set({ packs: updated, downloading: null });
+  },
+
+  removePack: async (destinationId) => {
+    const updated = get().packs.filter((p) => p.destinationId !== destinationId);
+    await storage.setItem(OFFLINE_PACKS_KEY, JSON.stringify(updated));
+    await storage.removeItem(`offline_pack_${destinationId}`);
+    set({ packs: updated });
+  },
+
+  getPackData: async (destinationId) => {
+    try {
+      const raw = await storage.getItem(`offline_pack_${destinationId}`);
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  },
+
+  isDownloaded: (destinationId) => {
+    return get().packs.some((p) => p.destinationId === destinationId);
+  },
+
+  getPackMeta: (destinationId) => {
+    return get().packs.find((p) => p.destinationId === destinationId);
+  },
+
+  setDownloading: (destinationId) => set({ downloading: destinationId }),
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@react-native-community/datetimepicker':
         specifier: 8.6.0
         version: 8.6.0(expo@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@react-native-community/netinfo':
+        specifier: 11.5.2
+        version: 11.5.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@react-native-google-signin/google-signin':
         specifier: ^16.1.2
         version: 16.1.2(expo@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -1711,6 +1714,12 @@ packages:
         optional: true
       react-native-windows:
         optional: true
+
+  '@react-native-community/netinfo@11.5.2':
+    resolution: {integrity: sha512-/g0m65BtX9HU+bPiCH2517bOHpEIUsGrWFXDzi1a5nNKn5KujQgm04WhL7/OSXWKHyrT8VVtUoJA0XKRxueBpQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '>=0.59'
 
   '@react-native-google-signin/google-signin@16.1.2':
     resolution: {integrity: sha512-1hf4pRmpnS5t0dHtqU72Q1FmWzsCZR2Sm3uVQbbfMKeNPl5TKjpAsP6F8QTZ9L+Q6Cnn9tL9BXpDCb1nyutdCQ==}
@@ -6461,6 +6470,11 @@ snapshots:
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     optionalDependencies:
       expo: 55.0.4(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.4)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+
+  '@react-native-community/netinfo@11.5.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
   '@react-native-google-signin/google-signin@16.1.2(expo@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:


### PR DESCRIPTION
…end tests, place detail screen

- Added offline pack download button on trip detail screen using AsyncStorage

- Created network status store with NetInfo and offline banner across all screens

- Added pack version check on reconnect with update alert

- Wrote backend tests for trip, user, and itinerary services

- Built place detail screen (app/place/[id]) wired from Explore tab

- Hydrate offline store and start network listener on app boot

Made-with: Cursor