### PR TITLE
feat: trip share/export, notification preferences, backend tests for …

### DIFF
--- a/apps/api/src/modules/currency/service.test.ts
+++ b/apps/api/src/modules/currency/service.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import type { AppError } from "../../middleware/errorHandler";
+
+process.env.NODE_ENV = "development";
+process.env.JWT_ACCESS_SECRET ??= "test_access_secret_1234567890";
+process.env.JWT_REFRESH_SECRET ??= "test_refresh_secret_1234567890";
+
+const { currencyService } = await import("./service");
+
+describe("currencyService", () => {
+  test("listSupported returns a non-empty array", () => {
+    const list = currencyService.listSupported();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBeGreaterThan(0);
+  });
+
+  test("each supported entry has code, name, and country", () => {
+    const list = currencyService.listSupported();
+    for (const entry of list.slice(0, 5)) {
+      expect(typeof entry.code).toBe("string");
+      expect(typeof entry.name).toBe("string");
+      expect(typeof entry.country).toBe("string");
+    }
+  });
+
+  test("isSupportedCode returns true for USD", () => {
+    expect(currencyService.isSupportedCode("USD")).toBe(true);
+  });
+
+  test("isSupportedCode returns true case-insensitively", () => {
+    expect(currencyService.isSupportedCode("usd")).toBe(true);
+    expect(currencyService.isSupportedCode("Eur")).toBe(true);
+  });
+
+  test("isSupportedCode returns false for made-up code", () => {
+    expect(currencyService.isSupportedCode("XYZ123")).toBe(false);
+  });
+
+  test("ratesForBase returns data for USD", async () => {
+    const result = await currencyService.ratesForBase("USD");
+    expect(result).toBeDefined();
+    expect(typeof result).toBe("object");
+  });
+
+  test("ratesForBase throws 404 for unsupported code", async () => {
+    await expect(currencyService.ratesForBase("ZZZZZ")).rejects.toMatchObject({
+      statusCode: 404,
+      code: "NOT_FOUND",
+    } satisfies Partial<AppError>);
+  });
+});

--- a/apps/api/src/modules/message/service.ts
+++ b/apps/api/src/modules/message/service.ts
@@ -55,10 +55,13 @@ export const messageService = {
     });
     const preview =
       content.length > 80 ? `${content.slice(0, 77).trimEnd()}…` : content;
-    void notifyUserPush(otherUserId, `Message from ${sender?.name ?? "Traveler"}`, preview, {
-      type: "message",
-      connectionId,
-    });
+    void notifyUserPush(
+      otherUserId,
+      `Message from ${sender?.name ?? "Traveler"}`,
+      preview,
+      { type: "message", connectionId },
+      "message"
+    );
 
     return formatMessage(message);
   },

--- a/apps/api/src/modules/social/service.test.ts
+++ b/apps/api/src/modules/social/service.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { prisma } from "@repo/db";
+
+process.env.NODE_ENV = "development";
+process.env.JWT_ACCESS_SECRET ??= "test_access_secret_1234567890";
+process.env.JWT_REFRESH_SECRET ??= "test_refresh_secret_1234567890";
+
+const { connectionService } = await import("./service");
+const { authService } = await import("../auth/service");
+
+const runId = `social_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const createdUserIds = new Set<string>();
+const createdConnectionIds = new Set<string>();
+
+async function createTestUser(suffix: string, opts?: { socialOptIn?: boolean }) {
+  const result = await authService.register(
+    `${runId}_${suffix}@test.local`,
+    "Password456!",
+    `Social User ${suffix}`,
+    `${runId}_${suffix}`
+  );
+  createdUserIds.add(result.user.id);
+
+  if (opts?.socialOptIn) {
+    await prisma.user.update({
+      where: { id: result.user.id },
+      data: { socialOptIn: true },
+    });
+  }
+
+  return result.user;
+}
+
+async function createOverlappingTrips(userId1: string, userId2: string, destId: string) {
+  const now = new Date();
+  const later = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  const t1 = await prisma.trip.create({
+    data: { ownerId: userId1, destinationId: destId, title: "Trip A", startDate: now, endDate: later },
+  });
+  const t2 = await prisma.trip.create({
+    data: { ownerId: userId2, destinationId: destId, title: "Trip B", startDate: now, endDate: later },
+  });
+  return [t1.id, t2.id];
+}
+
+afterEach(async () => {
+  if (createdConnectionIds.size > 0) {
+    await prisma.connection.deleteMany({
+      where: { id: { in: [...createdConnectionIds] } },
+    });
+    createdConnectionIds.clear();
+  }
+});
+
+afterAll(async () => {
+  if (createdUserIds.size > 0) {
+    await prisma.itineraryItem.deleteMany({
+      where: { trip: { ownerId: { in: [...createdUserIds] } } },
+    });
+    await prisma.trip.deleteMany({
+      where: { ownerId: { in: [...createdUserIds] } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { in: [...createdUserIds] } },
+    });
+  }
+  await prisma.$disconnect();
+});
+
+describe("connectionService", () => {
+  test("cannot connect to yourself", async () => {
+    const user = await createTestUser("self", { socialOptIn: true });
+    await expect(connectionService.create(user.id, user.id)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  test("cannot connect to user without socialOptIn", async () => {
+    const sender = await createTestUser("sender1", { socialOptIn: true });
+    const receiver = await createTestUser("receiver1_nooption");
+
+    const dest = await prisma.destination.findFirst({ select: { id: true } });
+    if (!dest) return;
+    await createOverlappingTrips(sender.id, receiver.id, dest.id);
+
+    await expect(connectionService.create(sender.id, receiver.id)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  test("create connection and list it", async () => {
+    const sender = await createTestUser("sender2", { socialOptIn: true });
+    const receiver = await createTestUser("receiver2", { socialOptIn: true });
+
+    const dest = await prisma.destination.findFirst({ select: { id: true } });
+    if (!dest) return;
+    await createOverlappingTrips(sender.id, receiver.id, dest.id);
+
+    const result = await connectionService.create(sender.id, receiver.id);
+    createdConnectionIds.add(result.connection.id);
+
+    expect(result.connection.status).toBe("PENDING");
+    expect(result.connection.requesterId).toBe(sender.id);
+    expect(result.connection.receiverId).toBe(receiver.id);
+  });
+
+  test("duplicate connection throws conflict", async () => {
+    const sender = await createTestUser("sender3", { socialOptIn: true });
+    const receiver = await createTestUser("receiver3", { socialOptIn: true });
+
+    const dest = await prisma.destination.findFirst({ select: { id: true } });
+    if (!dest) return;
+    await createOverlappingTrips(sender.id, receiver.id, dest.id);
+
+    const result = await connectionService.create(sender.id, receiver.id);
+    createdConnectionIds.add(result.connection.id);
+
+    await expect(connectionService.create(sender.id, receiver.id)).rejects.toMatchObject({
+      statusCode: 409,
+    });
+  });
+
+  test("accept connection changes status", async () => {
+    const sender = await createTestUser("sender4", { socialOptIn: true });
+    const receiver = await createTestUser("receiver4", { socialOptIn: true });
+
+    const dest = await prisma.destination.findFirst({ select: { id: true } });
+    if (!dest) return;
+    await createOverlappingTrips(sender.id, receiver.id, dest.id);
+
+    const created = await connectionService.create(sender.id, receiver.id);
+    createdConnectionIds.add(created.connection.id);
+
+    const updated = await connectionService.updateStatus(
+      receiver.id,
+      created.connection.id,
+      "ACCEPTED"
+    );
+    expect(updated.connection.status).toBe("ACCEPTED");
+  });
+
+  test("only receiver can accept/reject", async () => {
+    const sender = await createTestUser("sender5", { socialOptIn: true });
+    const receiver = await createTestUser("receiver5", { socialOptIn: true });
+
+    const dest = await prisma.destination.findFirst({ select: { id: true } });
+    if (!dest) return;
+    await createOverlappingTrips(sender.id, receiver.id, dest.id);
+
+    const created = await connectionService.create(sender.id, receiver.id);
+    createdConnectionIds.add(created.connection.id);
+
+    await expect(
+      connectionService.updateStatus(sender.id, created.connection.id, "ACCEPTED")
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+});

--- a/apps/api/src/modules/social/service.ts
+++ b/apps/api/src/modules/social/service.ts
@@ -343,7 +343,8 @@ export const connectionService = {
       receiverId,
       "New connection request",
       `${requester?.name ?? "A traveler"} wants to connect`,
-      { type: "connection_request", connectionId: created.id }
+      { type: "connection_request", connectionId: created.id },
+      "connection_request"
     );
 
     return formatConnection(created);
@@ -377,7 +378,8 @@ export const connectionService = {
         updated.requesterId,
         "Connection accepted",
         `${accepter?.name ?? "Your connection"} accepted your request`,
-        { type: "connection_accepted", connectionId: updated.id }
+        { type: "connection_accepted", connectionId: updated.id },
+        "connection_accepted"
       );
     }
 

--- a/apps/api/src/modules/user/index.ts
+++ b/apps/api/src/modules/user/index.ts
@@ -10,6 +10,8 @@ const MeUser = t.Object({
   avatarUrl: t.Union([t.String(), t.Null()]),
   bio: t.Union([t.String(), t.Null()]),
   socialOptIn: t.Boolean(),
+  notifyMessages: t.Boolean(),
+  notifyConnections: t.Boolean(),
   friendCount: t.Integer({ minimum: 0 }),
   tripCount: t.Integer({ minimum: 0 }),
 });
@@ -24,6 +26,8 @@ const UpdateProfileBody = t.Object({
   bio: t.Optional(t.Union([t.String({ maxLength: 300 }), t.Null()])),
   socialOptIn: t.Optional(t.Boolean()),
   avatarUrl: t.Optional(t.Union([t.String({ maxLength: 2000 }), t.Null()])),
+  notifyMessages: t.Optional(t.Boolean()),
+  notifyConnections: t.Optional(t.Boolean()),
 });
 
 const PushTokenBody = t.Object({

--- a/apps/api/src/modules/user/service.ts
+++ b/apps/api/src/modules/user/service.ts
@@ -22,6 +22,8 @@ export const userService = {
         avatarUrl: true,
         bio: true,
         socialOptIn: true,
+        notifyMessages: true,
+        notifyConnections: true,
         _count: {
           select: {
             trips: { where: { deletedAt: null } },
@@ -46,7 +48,15 @@ export const userService = {
 
   async updateProfile(
     userId: string,
-    data: { name?: string; username?: string; bio?: string | null; socialOptIn?: boolean; avatarUrl?: string | null }
+    data: {
+      name?: string;
+      username?: string;
+      bio?: string | null;
+      socialOptIn?: boolean;
+      avatarUrl?: string | null;
+      notifyMessages?: boolean;
+      notifyConnections?: boolean;
+    }
   ) {
     if (data.username) {
       const existing = await prisma.user.findUnique({
@@ -66,6 +76,8 @@ export const userService = {
         ...(data.bio !== undefined && { bio: data.bio }),
         ...(data.socialOptIn !== undefined && { socialOptIn: data.socialOptIn }),
         ...(data.avatarUrl !== undefined && { avatarUrl: data.avatarUrl }),
+        ...(data.notifyMessages !== undefined && { notifyMessages: data.notifyMessages }),
+        ...(data.notifyConnections !== undefined && { notifyConnections: data.notifyConnections }),
       },
       select: {
         id: true,
@@ -75,6 +87,8 @@ export const userService = {
         avatarUrl: true,
         bio: true,
         socialOptIn: true,
+        notifyMessages: true,
+        notifyConnections: true,
         _count: {
           select: {
             trips: { where: { deletedAt: null } },

--- a/apps/api/src/modules/weather/service.test.ts
+++ b/apps/api/src/modules/weather/service.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+process.env.NODE_ENV = "development";
+process.env.JWT_ACCESS_SECRET ??= "test_access_secret_1234567890";
+process.env.JWT_REFRESH_SECRET ??= "test_refresh_secret_1234567890";
+
+const { weatherService } = await import("./service");
+
+describe("weatherService", () => {
+  test("forecast returns current and daily data for valid coords", async () => {
+    const result = await weatherService.forecast({
+      latitude: 35.6762,
+      longitude: 139.6503,
+      forecastDays: 3,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("current");
+    expect(result).toHaveProperty("daily");
+  });
+
+  test("forecast clamps days to max 16", async () => {
+    const result = await weatherService.forecast({
+      latitude: 48.8566,
+      longitude: 2.3522,
+      forecastDays: 30,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("current");
+  });
+
+  test("forecast clamps days to min 1", async () => {
+    const result = await weatherService.forecast({
+      latitude: 40.7128,
+      longitude: -74.006,
+      forecastDays: -5,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("current");
+  });
+
+  test("forecast defaults to 7 days when not specified", async () => {
+    const result = await weatherService.forecast({
+      latitude: 51.5074,
+      longitude: -0.1278,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("daily");
+    const daily = result.daily as Record<string, unknown[]>;
+    expect(daily.time?.length).toBe(7);
+  });
+
+  test("forecast accepts custom timezone", async () => {
+    const result = await weatherService.forecast({
+      latitude: 35.6762,
+      longitude: 139.6503,
+      timezone: "Asia/Tokyo",
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("timezone");
+    expect(result.timezone).toBe("Asia/Tokyo");
+  });
+});

--- a/apps/api/src/utils/notifyUserPush.ts
+++ b/apps/api/src/utils/notifyUserPush.ts
@@ -1,12 +1,26 @@
 import { prisma } from "@repo/db";
 import { sendExpoPushToUserTokens } from "./pushNotifications";
 
+type NotificationType = "message" | "connection_request" | "connection_accepted" | "general";
+
 export async function notifyUserPush(
   userId: string,
   title: string,
   body: string,
-  data?: Record<string, string>
+  data?: Record<string, string>,
+  type: NotificationType = "general"
 ): Promise<void> {
+  if (type === "message" || type === "connection_request" || type === "connection_accepted") {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { notifyMessages: true, notifyConnections: true },
+    });
+
+    if (!user) return;
+    if (type === "message" && !user.notifyMessages) return;
+    if ((type === "connection_request" || type === "connection_accepted") && !user.notifyConnections) return;
+  }
+
   const tokens = await prisma.pushDevice.findMany({
     where: { userId },
     select: { expoToken: true },

--- a/apps/mobile/src/app/settings.tsx
+++ b/apps/mobile/src/app/settings.tsx
@@ -1,7 +1,8 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { ChevronLeft, ChevronRight, MessageCircle, Ruler, User, Users } from "lucide-react-native";
+import { Bell, ChevronLeft, ChevronRight, MessageCircle, Ruler, User, Users } from "lucide-react-native";
 import { useUnstableNativeVariable } from "nativewind";
-import { Alert, Pressable, Text, View } from "react-native";
+import { Alert, Pressable, Switch, Text, View } from "react-native";
 import { client } from "@/api/client";
 import { Button } from "@/components/shared/Button";
 import { Screen } from "@/components/shared/Screen";
@@ -35,6 +36,7 @@ function TabChip({
 
 export default function SettingsScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
   const unitSystem = usePreferencesStore((s) => s.unitSystem);
@@ -42,6 +44,28 @@ export default function SettingsScreen() {
 
   const iconColor = useUnstableNativeVariable("--foreground");
   const resolvedIcon = iconColor ? `hsl(${iconColor})` : undefined;
+
+  const profileQuery = useQuery({
+    queryKey: ["user", "me"],
+    queryFn: async () => {
+      const res = await client.api.v1.users.me.get();
+      if (res.error) throw new Error("Failed to load profile");
+      return res.data;
+    },
+  });
+
+  const notifMutation = useMutation({
+    mutationFn: async (data: { notifyMessages?: boolean; notifyConnections?: boolean }) => {
+      const res = await client.api.v1.users.me.patch(data);
+      if (res.error) throw new Error("Failed to update");
+      return res.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["user", "me"] }),
+  });
+
+  const profile = profileQuery.data?.user as
+    | { notifyMessages: boolean; notifyConnections: boolean }
+    | undefined;
 
   const handleSignOut = () => {
     Alert.alert("Sign Out", "Are you sure you want to sign out?", [
@@ -123,6 +147,45 @@ export default function SettingsScreen() {
               <Text className="mt-2 text-xs text-muted-foreground">
                 {unitSystem === "metric" ? "°C · km · km/h" : "°F · mi · mph"}
               </Text>
+            </View>
+          </View>
+        </View>
+
+        <View className="rounded-2xl border border-border bg-card p-4">
+          <View className="flex-row items-start gap-3">
+            <View className="mt-0.5 rounded-full bg-primary/15 p-2">
+              <Bell size={18} color={resolvedIcon} />
+            </View>
+            <View className="min-w-0 flex-1 gap-4">
+              <Text className="text-base font-semibold text-foreground">Notifications</Text>
+
+              <View className="flex-row items-center justify-between">
+                <View className="flex-1 pr-4">
+                  <Text className="text-sm font-medium text-foreground">Messages</Text>
+                  <Text className="text-xs text-muted-foreground">
+                    Get notified when you receive a new message
+                  </Text>
+                </View>
+                <Switch
+                  value={profile?.notifyMessages ?? true}
+                  onValueChange={(val) => notifMutation.mutate({ notifyMessages: val })}
+                  disabled={!profile || notifMutation.isPending}
+                />
+              </View>
+
+              <View className="flex-row items-center justify-between">
+                <View className="flex-1 pr-4">
+                  <Text className="text-sm font-medium text-foreground">Connections</Text>
+                  <Text className="text-xs text-muted-foreground">
+                    Get notified for connection requests and acceptances
+                  </Text>
+                </View>
+                <Switch
+                  value={profile?.notifyConnections ?? true}
+                  onValueChange={(val) => notifMutation.mutate({ notifyConnections: val })}
+                  disabled={!profile || notifMutation.isPending}
+                />
+              </View>
             </View>
           </View>
         </View>

--- a/apps/mobile/src/app/trip/[id].tsx
+++ b/apps/mobile/src/app/trip/[id].tsx
@@ -12,6 +12,7 @@ import {
   MapPin,
   PackageCheck,
   Plus,
+  Share2,
   Trash2,
 } from "lucide-react-native";
 import { useUnstableNativeVariable } from "nativewind";
@@ -23,6 +24,7 @@ import {
   Modal,
   Platform,
   Pressable,
+  Share,
   Text,
   TextInput,
   View,
@@ -198,6 +200,36 @@ export default function TripDetailScreen() {
     onError: () => setDownloading(null),
   });
 
+  const shareTrip = async () => {
+    if (!trip) return;
+    const grouped = groupByDate(items);
+    let text = `${trip.title}\n`;
+    text += `${trip.destination.name}, ${trip.destination.country}\n`;
+    text += `${formatDate(trip.startDate)} – ${formatDate(trip.endDate)}\n\n`;
+
+    if (grouped.length === 0) {
+      text += "No itinerary items yet.";
+    } else {
+      for (const [date, dayItems] of grouped) {
+        text += `📅 ${formatDate(date)}\n`;
+        for (const item of dayItems) {
+          const check = item.isDone ? "✅" : "⬜";
+          const time = item.startTime ? ` (${item.startTime})` : "";
+          text += `  ${check} ${item.title}${time}\n`;
+          if (item.notes) text += `     ${item.notes}\n`;
+        }
+        text += "\n";
+      }
+      text += `Progress: ${doneCount}/${items.length} complete`;
+    }
+
+    try {
+      await Share.share({ message: text });
+    } catch {
+      // User cancelled
+    }
+  };
+
   if (tripQuery.isLoading) {
     return (
       <Screen>
@@ -248,6 +280,12 @@ export default function TripDetailScreen() {
             </View>
             <View className="flex-row items-center justify-between">
               <Text className="flex-1 text-2xl font-bold text-foreground">{trip.title}</Text>
+              <Pressable
+                onPress={shareTrip}
+                className="ml-2 rounded-lg border border-border bg-card p-2 active:opacity-80"
+              >
+                <Share2 size={16} color={mutedColor} />
+              </Pressable>
               <Pressable
                 onPress={() => guardAction(() => setShowEditModal(true))}
                 className="ml-2 rounded-lg border border-border bg-card p-2 active:opacity-80"

--- a/packages/db/prisma/migrations/20260424120000_add_notification_preferences/migration.sql
+++ b/packages/db/prisma/migrations/20260424120000_add_notification_preferences/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "notifyMessages" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "User" ADD COLUMN "notifyConnections" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -37,6 +37,8 @@ model User {
   homeCountry         String? // ISO country code
   preferredLanguageId String?
   socialOptIn         Boolean @default(false)
+  notifyMessages      Boolean @default(true)
+  notifyConnections   Boolean @default(true)
 
   isVerified Boolean @default(false)
   isActive   Boolean @default(true)


### PR DESCRIPTION
…weather/currency/social

- Added share button on trip detail that exports formatted itinerary to native share sheet

- Added notifyMessages and notifyConnections fields to User model with migration

- Updated user service and API to support notification preference toggles

- Push notification sender now checks user preferences before sending

- Added notification preferences UI in settings with toggle switches

- Wrote backend tests for weather service (forecast, day clamping, timezone)

- Wrote backend tests for currency service (supported list, rates, validation)

- Wrote backend tests for social/connection service (create, accept, reject, validation)

Made-with: Cursor